### PR TITLE
Enhance FPSMonitor addon

### DIFF
--- a/FPSMonitor/FPSMonitor.toc
+++ b/FPSMonitor/FPSMonitor.toc
@@ -2,7 +2,7 @@
 ## Title: FPS Monitor
 ## Notes: Displays advanced FPS statistics
 ## Author: Renvulf
-## Version: 1.0
+## Version: 1.1
 ## SavedVariables: FPSMonitorDB
 ## SavedVariablesPerCharacter: FPSPerCharDB
 ## IconTexture: Interface\AddOns\FPSMonitor\FPS1.tga


### PR DESCRIPTION
## Summary
- add saved variable defaults and deep merge utility
- restore frame position and allow minimap button to be hidden
- add commands to reset statistics and toggle the minimap icon
- clamp long frame samples and handle config loading on ADDON_LOADED
- bump version

## Testing
- `git status --short`
- `luac` not installed; syntax check skipped

------
https://chatgpt.com/codex/tasks/task_e_685c8af274ac8328903d11da5f2ab1f8