### PR TITLE
Improve WoW FPS Monitor addon

### DIFF
--- a/FPSMonitor/FPSMonitor.toc
+++ b/FPSMonitor/FPSMonitor.toc
@@ -1,8 +1,8 @@
 ## Interface: 110105
 ## Title: FPS Monitor
-## Notes: Displays advanced FPS statistics
+## Notes: Displays advanced FPS statistics with a draggable minimap button
 ## Author: Renvulf
-## Version: 1.1
+## Version: 1.2
 ## SavedVariables: FPSMonitorDB
 ## SavedVariablesPerCharacter: FPSPerCharDB
 ## IconTexture: Interface\AddOns\FPSMonitor\FPS1.tga


### PR DESCRIPTION
## Summary
- track minimap button angle in the saved variables
- allow dragging the minimap button around the minimap
- color current FPS value in the display
- make reset command restore internal counters
- update addon metadata

## Testing
- `luac -p FPSMonitor.lua`

------
https://chatgpt.com/codex/tasks/task_e_685c947be040832891855a47af738047