### PR TITLE
Improve FPS monitor display and layout

### DIFF
--- a/FPSMonitor/FPSMonitor.toc
+++ b/FPSMonitor/FPSMonitor.toc
@@ -2,7 +2,7 @@
 ## Title: FPS Monitor
 ## Notes: Displays advanced FPS statistics with a draggable minimap button
 ## Author: Renvulf
-## Version: 1.2
+## Version: 1.3
 ## SavedVariables: FPSMonitorDB
 ## SavedVariablesPerCharacter: FPSPerCharDB
 ## IconTexture: Interface\AddOns\FPSMonitor\FPS1.tga


### PR DESCRIPTION
## Summary
- enhance layout and styling of FPS stats
- use bundled Pepsi.ttf font with safe fallback
- bump addon version to 1.3

## Testing
- `luac -p FPSMonitor.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c9b72647883288e6bd8a73dee62e6