### PR TITLE
Improve FPS monitor addon

### DIFF
--- a/FPSMonitor/FPSMonitor.toc
+++ b/FPSMonitor/FPSMonitor.toc
@@ -2,7 +2,7 @@
 ## Title: FPS Monitor
 ## Notes: Displays advanced FPS statistics with a draggable minimap button
 ## Author: Renvulf
-## Version: 1.3
+## Version: 1.4
 ## SavedVariables: FPSMonitorDB
 ## SavedVariablesPerCharacter: FPSPerCharDB
 ## IconTexture: Interface\AddOns\FPSMonitor\FPS1.tga


### PR DESCRIPTION
## Summary
- add local references to WoW globals for minor perf gains
- persist min/max FPS across sessions per-character
- add slash commands for stats and resets
- print stats helper and update character stats
- bump version to 1.4

## Testing
- `luac -p FPSMonitor.lua`

------
https://chatgpt.com/codex/tasks/task_e_685c9c772308832888f96244dd743b60