### PR TITLE
Enhance FPSMonitor addon

### DIFF
--- a/FPSMonitor/FPSMonitor.toc
+++ b/FPSMonitor/FPSMonitor.toc
@@ -2,7 +2,7 @@
 ## Title: FPS Monitor
 ## Notes: Displays advanced FPS statistics with a draggable minimap button
 ## Author: Renvulf
-## Version: 1.4
+## Version: 1.5
 ## SavedVariables: FPSMonitorDB
 ## SavedVariablesPerCharacter: FPSPerCharDB
 ## IconTexture: Interface\AddOns\FPSMonitor\FPS1.tga


### PR DESCRIPTION
## Summary
- optimize math global usage
- ensure minimap angle setting is numeric
- show FPS stats on minimap button tooltip
- bump addon version

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685c9fdd3790832895f5f011fd082b2a