### PR TITLE
Enhance FPSMonitor stats handling

### DIFF
--- a/FPSMonitor/FPSMonitor.toc
+++ b/FPSMonitor/FPSMonitor.toc
@@ -2,7 +2,7 @@
 ## Title: FPS Monitor
 ## Notes: Displays advanced FPS statistics with a draggable minimap button
 ## Author: Renvulf
-## Version: 1.5
+## Version: 1.6
 ## SavedVariables: FPSMonitorDB
 ## SavedVariablesPerCharacter: FPSPerCharDB
 ## IconTexture: Interface\AddOns\FPSMonitor\FPS1.tga


### PR DESCRIPTION
## Summary
- streamline FPS calculations using running sums
- reset sums when clearing history
- bump addon version

## Testing
- `luac -p FPSMonitor/FPSMonitor.lua`
- `luacheck FPSMonitor/FPSMonitor.lua`

------
https://chatgpt.com/codex/tasks/task_e_685ca9386ce4832894d37166014c7783