### PR TITLE
Fix FPS monitor labels missing

### DIFF
--- a/FPSMonitor/FPSMonitor.lua
+++ b/FPSMonitor/FPSMonitor.lua
@@ -364,12 +364,12 @@ local function CreateDisplayFrame()
     local y = -30
     for i, text in ipairs(statsLabels) do
         local label = displayFrame:CreateFontString(nil, "ARTWORK")
-        label:SetPoint("TOPLEFT", 10, y)
+        label:SetPoint("TOPLEFT", displayFrame, "TOPLEFT", 10, y)
         SetFontSafe(label, 12)
         label:SetText(text .. ":")
 
         local value = displayFrame:CreateFontString(nil, "ARTWORK")
-        value:SetPoint("TOPRIGHT", -10, y)
+        value:SetPoint("TOPRIGHT", displayFrame, "TOPRIGHT", -10, y)
         value:SetJustifyH("RIGHT")
         SetFontSafe(value, 12, "OUTLINE")
 


### PR DESCRIPTION
## Summary
- fix label anchoring when creating the display frame

## Testing
- `luacheck --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cb0c2c3188328968c99afff71a119