### PR TITLE
Enable font selection from addon directories

### DIFF
--- a/FCTF/FCTF.lua
+++ b/FCTF/FCTF.lua
@@ -1,37 +1,97 @@
 -- FCTF.lua
 local addonName = ...
 local ADDON_PATH = "Interface\\AddOns\\" .. addonName .. "\\"
-local MAX_FONTS = 20
+--[[
+  ---------------------------------------------------------------------------
+    Font Detection
+    Instead of checking for numbered fonts like 1.ttf, 2.ttf, etc. we now look
+    for actual font files organised into folders. Each folder corresponds to a
+    themed group of fonts. The table below lists the relative font file names
+    shipped with the addon. Detection is performed at load time so missing
+    files are ignored gracefully.
+  ---------------------------------------------------------------------------
+--]]
 
 -- SavedDB defaults
 if not FCTFDB then
     FCTFDB = { minimapAngle = 45 }
 end
+FCTFPCDB = FCTFPCDB or {}
 
--- 1) PRELOAD & DETECT NUMBERED FONTS AT 32px
+local PERCHAR_DEFAULTS = {
+    combatHealing  = tonumber(GetCVar("floatingCombatTextCombatHealing")) == 1,
+    combatDamage   = tonumber(GetCVar("floatingCombatTextCombatDamage")) == 1,
+    petDamage      = tonumber(GetCVar("floatingCombatTextPetMeleeDamage")) == 1,
+    periodicDamage = tonumber(GetCVar("floatingCombatTextPeriodicDamage")) == 1,
+}
+for k,v in pairs(PERCHAR_DEFAULTS) do
+    if FCTFPCDB[k] == nil then FCTFPCDB[k] = v end
+end
+
+local COMBAT_FONT_GROUPS = {
+    ["Fun"] = {
+        path  = ADDON_PATH .. "Fun\\",
+        fonts = {
+            "04b.ttf", "Barriecito.ttf", "ComicRunes.ttf", "Green Fuz.otf",
+            "Guroes.ttf", "Melted.ttf", "Midorima.ttf", "Munsteria.ttf",
+            "Runic.ttf", "Runy.ttf", "Shiruken.ttf", "Skullphabet.ttf",
+            "WhoAsksSatan.ttf", "Wickedmouse.ttf", "akash.ttf", "edgyh.ttf",
+            "edkies.ttf", "graff.ttf", "shog.ttf",
+        },
+    },
+    ["Future"] = {
+        path  = ADDON_PATH .. "Future\\",
+        fonts = {
+            "914Solid.ttf", "ChopSic.ttf", "Digital.ttf", "FastHand.ttf",
+            "Orbitron.ttf", "Pepsi.ttf", "RaceSpace.ttf", "RushDriver.ttf",
+        },
+    },
+    ["Movie/Game"] = {
+        path  = ADDON_PATH .. "MovieGame\\",
+        fonts = {
+            "Deltarune.ttf", "Halo.ttf", "HarryP.ttf", "Pokemon.ttf",
+            "Spongebob.ttf", "Terminator.ttf", "modernwarfare.ttf",
+        },
+    },
+    ["Easy-to-Read"] = {
+        path  = ADDON_PATH .. "Easy-to-Read\\",
+        fonts = {
+            "AlteHaasGroteskBold.ttf", "Expressway.ttf",
+            "NotoSans_Condensed-Bold.ttf", "PTSansNarrow-Bold.ttf",
+            "Prototype.ttf", "Roboto-Bold.ttf", "SF-Pro.ttf",
+            "accidentalpres.ttf", "bignoodletitling.ttf", "continuum.ttf",
+            "pf_tempesta_seven.ttf",
+        },
+    },
+    ["Default"] = {
+        path  = ADDON_PATH,
+        fonts = {"default.ttf"},
+    },
+}
+
+-- Cache loaded fonts to allow previewing in the options panel
 local cachedFonts, existsFonts = {}, {}
-for i = 1, MAX_FONTS do
-    local path = ADDON_PATH .. i .. ".ttf"
-    local f = CreateFont(addonName .. "CacheFont" .. i)
-    f:SetFont(path, 32, "")
-    local loaded = f:GetFont()
-    if loaded and loaded:lower():find(i .. ".ttf", 1, true) then
-        existsFonts[i] = true
-        cachedFonts[i] = f
-    else
-        existsFonts[i] = false
+for group, data in pairs(COMBAT_FONT_GROUPS) do
+    cachedFonts[group] = {}
+    existsFonts[group] = {}
+    for _, fname in ipairs(data.fonts) do
+        local path = data.path .. fname
+        local f = CreateFont(addonName .. "Cache" .. group .. fname)
+        f:SetFont(path, 32, "")
+        local loaded = f:GetFont()
+        if loaded and loaded:lower():find(fname:lower(), 1, true) then
+            existsFonts[group][fname] = true
+            cachedFonts[group][fname] = {font=f, path=path}
+        else
+            existsFonts[group][fname] = false
+        end
     end
 end
 
--- 1b) PRELOAD & DETECT default.ttf
-local defaultFontObj = CreateFont(addonName .. "CacheFontDefault")
-defaultFontObj:SetFont(ADDON_PATH .. "default.ttf", 32, "")
-local defaultLoaded = defaultFontObj:GetFont()
-local defaultExists = (defaultLoaded and defaultLoaded:lower():find("default.ttf", 1, true)) and true or false
-
 -- 2) MAIN WINDOW
 local frame = CreateFrame("Frame", addonName .. "Frame", UIParent, "BackdropTemplate")
-frame:SetSize(360, 360)
+-- Expanded size to fit additional controls
+frame:SetSize(420, 480)
 frame:SetPoint("CENTER")
 frame:SetBackdrop({
     bgFile   = "Interface\\DialogFrame\\UI-DialogBox-Background",
@@ -52,35 +112,96 @@ if UISpecialFrames then
     tinsert(UISpecialFrames, frame:GetName())
 end
 
--- 3) FONT LABEL + DROPDOWN
-local fontLabel = frame:CreateFontString(nil, "OVERLAY", "GameFontNormal")
-fontLabel:SetPoint("TOPLEFT", frame, "TOPLEFT", 16, -16)
-fontLabel:SetText("Select Font:")
-local dropdown = CreateFrame("Frame", addonName .. "Dropdown", frame, "UIDropDownMenuTemplate")
-dropdown:SetPoint("LEFT", fontLabel, "RIGHT", 8, 0)
-UIDropDownMenu_SetWidth(dropdown, 140)
+-- 3) COMMON WIDGET HELPERS ---------------------------------------------------
+local function CreateCheckbox(parent, label, x, y, checked, onClick)
+    local cb = CreateFrame("CheckButton", nil, parent, "UICheckButtonTemplate")
+    cb:SetPoint("TOPLEFT", x, y)
+    cb.text:SetText(label)
+    cb:SetChecked(checked)
+    if onClick then cb:SetScript("OnClick", onClick) end
+    return cb
+end
 
--- 4) SCALE LABEL + LIVE NOTE
+-- 4) FONT DROPDOWNS ---------------------------------------------------------
+local dropdowns = {}
+local preview
+local editBox
+
+local function SetPreviewFont(fontObj, path)
+    if type(fontObj) == "table" then
+        path    = fontObj.path
+        fontObj = fontObj.font
+    end
+    local fPath, size, flags = fontObj:GetFont()
+    path  = path  or fPath
+    size  = (size or 20) * 2
+    flags = flags or ""
+    local ok = pcall(preview.SetFont, preview, path, size, flags)
+    if not ok then preview:SetFontObject(fontObj) end
+    local _, applied = preview:GetFont()
+    applied = applied or size
+    preview:SetHeight(applied + math.ceil(applied * 0.4))
+end
+
+local order = {"Fun", "Future", "Movie/Game", "Easy-to-Read", "Default"}
+for idx, grp in ipairs(order) do
+    local dd = CreateFrame("Frame", addonName .. grp:gsub("[^%w]", "") .. "DD", frame, "UIDropDownMenuTemplate")
+    local row = math.floor((idx-1)/2)
+    local col = (idx-1)%2
+    dd:SetPoint("TOPLEFT", frame, "TOPLEFT", 16 + col*200, -16 - row*50)
+    UIDropDownMenu_SetWidth(dd, 160)
+    dropdowns[grp] = dd
+    local label = frame:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
+    label:SetPoint("BOTTOMLEFT", dd, "TOPLEFT", 16, 3)
+    label:SetText(grp)
+
+    UIDropDownMenu_Initialize(dd, function()
+        local added = false
+        for _, fname in ipairs(COMBAT_FONT_GROUPS[grp].fonts) do
+            if existsFonts[grp][fname] then
+                added = true
+                local info = UIDropDownMenu_CreateInfo()
+                local display = fname:gsub("%.otf$", ""):gsub("%.ttf$", "")
+                local cache  = cachedFonts[grp][fname]
+                info.text  = display
+                info.func  = function()
+                    for g,d in pairs(dropdowns) do UIDropDownMenu_SetText(d, "Select Font") end
+                    FCTFDB.selectedFont = grp .. "/" .. fname
+                    UIDropDownMenu_SetText(dd, display)
+                    SetPreviewFont(cache)
+                    local txt = editBox:GetText()
+                    preview:SetText("")
+                    preview:SetText(txt)
+                end
+                info.checked = (FCTFDB.selectedFont == grp .. "/" .. fname)
+                UIDropDownMenu_AddButton(info)
+            end
+        end
+        if not added then
+            local info = UIDropDownMenu_CreateInfo()
+            info.text = "No font detected"
+            info.disabled = true
+            UIDropDownMenu_AddButton(info)
+        end
+    end)
+end
+
+-- 5) SCALE SLIDER -----------------------------------------------------------
 local scaleLabel = frame:CreateFontString(nil, "OVERLAY", "GameFontNormal")
-scaleLabel:SetPoint("TOPLEFT", fontLabel, "BOTTOMLEFT", 0, -24)
-scaleLabel:SetText("Combat Text Scale:")
-local scaleLive = frame:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
-scaleLive:SetPoint("TOPLEFT", scaleLabel, "BOTTOMLEFT", 0, -4)
-scaleLive:SetText("(live adjustment)")
+scaleLabel:SetPoint("TOPLEFT", frame, "TOPLEFT", 16, -140)
+scaleLabel:SetText("Combat Text Size:")
 
--- 5) SLIDER & SCALE VALUE
 local slider = CreateFrame("Slider", addonName .. "ScaleSlider", frame, "OptionsSliderTemplate")
-slider:SetSize(328, 16)
-slider:SetPoint("TOPLEFT", scaleLive, "BOTTOMLEFT", 0, -8)
-slider:SetMinMaxValues(0.1, 10.0)
+slider:SetSize(300, 16)
+slider:SetPoint("TOPLEFT", scaleLabel, "BOTTOMLEFT", 0, -8)
+slider:SetMinMaxValues(0.5, 5.0)
 slider:SetValueStep(0.1)
 slider:SetObeyStepOnDrag(true)
-_G[slider:GetName() .. "Text"]:SetText("")
-_G[slider:GetName() .. "Low"]:SetText("0.1")
-_G[slider:GetName() .. "High"]:SetText("10.0")
+_G[slider:GetName() .. "Low"]:SetText("0.5")
+_G[slider:GetName() .. "High"]:SetText("5.0")
 
-local scaleValue = frame:CreateFontString(nil, "OVERLAY", "GameFontNormalLarge")
-scaleValue:SetPoint("TOP", slider, "BOTTOM", 0, -6)
+local scaleValue = frame:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
+scaleValue:SetPoint("LEFT", slider, "RIGHT", 10, 0)
 
 local function UpdateScale(val)
     val = math.floor(val * 10 + 0.5) / 10
@@ -91,94 +212,74 @@ end
 local currentScale = tonumber(GetCVar("WorldTextScale")) or 1.0
 slider:SetValue(currentScale)
 scaleValue:SetText(string.format("%.1f", currentScale))
-slider:SetScript("OnValueChanged", function(self, val) UpdateScale(val) end)
+slider:SetScript("OnValueChanged", function(self,val) UpdateScale(val) end)
 slider:SetScript("OnEnter", function(self)
     GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
-    GameTooltip:SetText("Drag to adjust combat text scale live", nil, nil, nil, nil, true)
+    GameTooltip:AddLine("Drag to adjust combat text size",1,1,1)
     GameTooltip:Show()
 end)
-slider:SetScript("OnLeave", function() GameTooltip:Hide() end)
+slider:SetScript("OnLeave", GameTooltip_Hide)
 
--- 6) PREVIEW TEXT + DYNAMIC HEIGHT + COLOR
-local preview = frame:CreateFontString(nil, "OVERLAY", "GameFontNormalLarge")
-preview:SetJustifyH("CENTER")
-preview:SetJustifyV("MIDDLE")
-preview:SetTextColor(1, 1, 0, 1)
-preview:SetPoint("TOP", scaleValue, "BOTTOM", 0, -12)
-preview:SetWidth(328)
-
-local function SetPreviewFont(obj)
-    preview:SetFontObject(obj)
-    local _, size = preview:GetFont()
-    local padding = math.ceil(size * 0.2)
-    preview:SetHeight(size + (padding * 2))
-end
+-- 6) PREVIEW & EDIT ---------------------------------------------------------
+preview = frame:CreateFontString(nil, "OVERLAY", "GameFontNormalLarge")
+preview:SetPoint("TOPLEFT", slider, "BOTTOMLEFT", 0, -20)
+preview:SetWidth(360)
+preview:SetJustifyH("LEFT")
+preview:SetText("12345")
 
 SetPreviewFont(GameFontNormalLarge)
-preview:SetText("Absorb 12340")
 
--- 7) CUSTOM PREVIEW EDIT BOX
-local editBox = CreateFrame("EditBox", addonName .. "PreviewEdit", frame, "InputBoxTemplate")
-editBox:SetSize(328, 24)
-editBox:SetPoint("TOP", preview, "BOTTOM", 0, -8)
+editBox = CreateFrame("EditBox", addonName .. "PreviewEdit", frame, "InputBoxTemplate")
+editBox:SetSize(360, 24)
+editBox:SetPoint("TOPLEFT", preview, "BOTTOMLEFT", 0, -8)
 editBox:SetAutoFocus(false)
-editBox:SetText("Absorb 12340")
-editBox:SetScript("OnTextChanged", function(self)
-    preview:SetText(self:GetText())
-end)
+editBox:SetText("12345")
+editBox:SetScript("OnTextChanged", function(self) preview:SetText(self:GetText()) end)
 
--- 8) INFO TEXT
-local infoText = frame:CreateFontString(nil, "OVERLAY", "GameFontNormal")
-infoText:SetPoint("TOP", editBox, "BOTTOM", 0, -8)
-infoText:SetText("Pick a font, adjust scale, or click Default")
+-- 7) COMBAT OPTION CHECKBOXES ----------------------------------------------
+local opts = {
+    {k="combatHealing",  l="Show Combat Healing",  c="floatingCombatTextCombatHealing"},
+    {k="combatDamage",   l="Show Combat Damage",   c="floatingCombatTextCombatDamage"},
+    {k="petDamage",      l="Show Pet Damage",      c="floatingCombatTextPetMeleeDamage"},
+    {k="periodicDamage", l="Show Periodic Damage", c="floatingCombatTextPeriodicDamage"},
+}
+for i,opt in ipairs(opts) do
+    local col = (i-1)%2
+    local row = math.floor((i-1)/2)
+    local cb = CreateCheckbox(frame, opt.l, 16 + col*200, -260 - row*30, FCTFPCDB[opt.k], function(self)
+        FCTFPCDB[opt.k] = self:GetChecked()
+        SetCVar(opt.c, self:GetChecked() and 1 or 0)
+    end)
+end
 
--- 9) SAVE BUTTON
-local saveBtn = CreateFrame("Button", nil, frame, "UIPanelButtonTemplate")
-saveBtn:SetSize(200, 24)
-saveBtn:SetPoint("BOTTOMLEFT", 16, 16)
-saveBtn:SetText("Save & Show Reminder")
-saveBtn:SetScript("OnClick", function()
-    if FCTFDB and FCTFDB.selectedFont then
+-- 8) APPLY & DEFAULT BUTTONS -----------------------------------------------
+local applyBtn = CreateFrame("Button", nil, frame, "UIPanelButtonTemplate")
+applyBtn:SetSize(120, 22)
+applyBtn:SetPoint("BOTTOMLEFT", 16, 16)
+applyBtn:SetText("Apply")
+applyBtn:SetScript("OnClick", function()
+    if FCTFDB.selectedFont then
         DAMAGE_TEXT_FONT = ADDON_PATH .. FCTFDB.selectedFont
-        print("|cFF00FF00[FCTF]|r Font saved. Restart WoW to apply.")
-        UIErrorsFrame:AddMessage("FCTF: please EXIT & RESTART WoW to apply.", 1, 1, 0)
+        print("|cFF00FF00[FCTF]|r Combat font saved. Restart WoW to apply.")
+        UIErrorsFrame:AddMessage("FCTF: please EXIT & RESTART WoW to apply.",1,1,0)
+    else
+        print("|cFFFF0000[FCTF]|r No font selected.")
     end
 end)
-saveBtn:SetScript("OnEnter", function(self)
-    GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
-    GameTooltip:SetText("Save your chosen font & remind to.restart WoW", nil, nil, nil, nil, true)
-    GameTooltip:Show()
-end)
-saveBtn:SetScript("OnLeave", function() GameTooltip:Hide() end)
 
--- 10) DEFAULT BUTTON
 local defaultBtn = CreateFrame("Button", nil, frame, "UIPanelButtonTemplate")
-defaultBtn:SetSize(100, 24)
-defaultBtn:SetPoint("BOTTOMLEFT", saveBtn, "TOPLEFT", 0, 8)
+defaultBtn:SetSize(100,22)
+defaultBtn:SetPoint("LEFT", applyBtn, "RIGHT", 8, 0)
 defaultBtn:SetText("Default")
 defaultBtn:SetScript("OnClick", function()
-    if defaultExists then
-        FCTFDB.selectedFont = "default.ttf"
-        DAMAGE_TEXT_FONT = ADDON_PATH .. "default.ttf"
-        SetCVar("WorldTextScale", "1")
-        slider:SetValue(1)
-        scaleValue:SetText("1.0")
-        SetPreviewFont(defaultFontObj)
-        preview:SetText(editBox:GetText())
-        UIDropDownMenu_SetText(dropdown, "Default")
-        print("|cFF00FF00[FCTF]|r Reset to default font & scale. Restart WoW to apply.")
-        UIErrorsFrame:AddMessage("FCTF: please EXIT & RESTART WoW to apply.", 1, 1, 0)
-    else
-        print("|cFFFF0000[FCTF]|r default.ttf not found!")
-        UIErrorsFrame:AddMessage("FCTF: default.ttf missing!", 1, 0, 0)
-    end
+    FCTFDB.selectedFont = "Default/default.ttf"
+    SetPreviewFont(cachedFonts["Default"]["default.ttf"]) 
+    editBox:SetText(editBox:GetText())
+    slider:SetValue(1.0); UpdateScale(1.0)
+    for g,d in pairs(dropdowns) do UIDropDownMenu_SetText(d, "Select Font") end
+    UIDropDownMenu_SetText(dropdowns["Default"], "default")
+    print("|cFF00FF00[FCTF]|r Reset to default font.")
 end)
-defaultBtn:SetScript("OnEnter", function(self)
-    GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
-    GameTooltip:SetText("Reset font to default.ttf & scale to 1", nil, nil, nil, nil, true)
-    GameTooltip:Show()
-end)
-defaultBtn:SetScript("OnLeave", function() GameTooltip:Hide() end)
 
 -- 11) CLOSE BUTTON
 local closeBtn = CreateFrame("Button", nil, frame, "UIPanelButtonTemplate")
@@ -199,50 +300,20 @@ SLASH_FCT3, SLASH_FCT4 = "/FLOAT", "/float"
 SLASH_FCT5, SLASH_FCT6 = "/FLOATING", "/floating"
 SLASH_FCT7, SLASH_FCT8 = "/FLOATINGTEXT", "/floatingtext"
 SlashCmdList["FCT"] = function()
-    UIDropDownMenu_Initialize(dropdown, function()
-        for i = 1, MAX_FONTS do
-            local info = UIDropDownMenu_CreateInfo()
-            info.text  = "Font " .. i
-            info.value = i
-            info.func  = function()
-                FCTFDB = FCTFDB or {}
-                FCTFDB.selectedFont = i .. ".ttf"
-                UIDropDownMenu_SetText(dropdown, info.text)
-                if existsFonts[i] then
-                    SetPreviewFont(cachedFonts[i])
-                    preview:SetText(editBox:GetText())
-                else
-                    SetPreviewFont(GameFontNormalLarge)
-                    preview:SetText("Font " .. i .. " not found")
-                end
-            end
-            info.checked = (FCTFDB and FCTFDB.selectedFont == i .. ".ttf")
-            UIDropDownMenu_AddButton(info)
-        end
-    end)
-
     if frame:IsShown() then
         frame:Hide()
         return
     end
 
-    if FCTFDB and FCTFDB.selectedFont then
-        local idx = tonumber(FCTFDB.selectedFont:match("^(%d+)"))
-        if idx and existsFonts[idx] then
-            DAMAGE_TEXT_FONT = ADDON_PATH .. FCTFDB.selectedFont
-            SetPreviewFont(cachedFonts[idx])
-            preview:SetText(editBox:GetText())
-            UIDropDownMenu_SetText(dropdown, "Font " .. idx)
-        else
-            SetPreviewFont(GameFontNormalLarge)
-            preview:SetText("Font " .. (idx or "?") .. " not found")
-            UIDropDownMenu_SetText(dropdown, FCTFDB.selectedFont)
+    for g,d in pairs(dropdowns) do UIDropDownMenu_SetText(d, "Select Font") end
+    if FCTFDB.selectedFont then
+        local grp,fname = FCTFDB.selectedFont:match("^([^/]+)/(.+)$")
+        if grp and fname and dropdowns[grp] and existsFonts[grp][fname] then
+            UIDropDownMenu_SetText(dropdowns[grp], fname:gsub("%.otf$",""):gsub("%.ttf$",""))
+            SetPreviewFont(cachedFonts[grp][fname])
         end
-    else
-        UIDropDownMenu_SetText(dropdown, "Select Font")
-        preview:SetText("")
     end
-
+    preview:SetText(editBox:GetText())
     frame:Show()
 end
 
@@ -300,18 +371,16 @@ end)
 frame:RegisterEvent("ADDON_LOADED")
 frame:SetScript("OnEvent", function(self, event, name)
     if name == addonName then
-        if not FCTFDB then FCTFDB = {} end
         if FCTFDB.selectedFont then
-            local idx = tonumber(FCTFDB.selectedFont:match("^(%d+)"))
-            if idx and existsFonts[idx] then
+            local g,f = FCTFDB.selectedFont:match("^([^/]+)/(.+)$")
+            if g and f and existsFonts[g] and existsFonts[g][f] then
                 DAMAGE_TEXT_FONT = ADDON_PATH .. FCTFDB.selectedFont
-                SetPreviewFont(cachedFonts[idx])
+                SetPreviewFont(cachedFonts[g][f])
                 preview:SetText(editBox:GetText())
-                UIDropDownMenu_SetText(dropdown, "Font " .. idx)
+                for grp,dd in pairs(dropdowns) do UIDropDownMenu_SetText(dd, "Select Font") end
+                UIDropDownMenu_SetText(dropdowns[g], f:gsub("%.otf$",""):gsub("%.ttf$",""))
             end
         end
-        if InterfaceOptions_AddCategory then
-            InterfaceOptions_AddCategory(frame)
-        end
+        if InterfaceOptions_AddCategory then InterfaceOptions_AddCategory(frame) end
     end
 end)


### PR DESCRIPTION
## Summary
- refactor FCTF font detection to use named folders
- add per-character combat text options and dropdowns for each font group
- redesign settings UI with font preview and combat text scale slider
- update slash command and loading logic for new font format

## Testing
- `luac -p FCTF/FCTF.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d0acd152483288179c6c0c1cb2bc6