### PR TITLE
Update SpellFly addon

### DIFF
--- a/SpellFly/SpellFly.lua
+++ b/SpellFly/SpellFly.lua
@@ -1,29 +1,72 @@
-local frame = CreateFrame("FRAME")
-frame:RegisterEvent("COMBAT_LOG_EVENT_UNFILTERED")
+-- SpellFly
+-- This addon animates spell icons so they fly off the screen whenever the
+-- player successfully casts a spell.  The effect is purely visual and does
+-- not interfere with normal spell functionality.
 
-local iconTexture, spellID, cooldownStartTime
+local SpellFly = CreateFrame("Frame")
 
-local function CreateIconCopy()
-  local iconCopy = CreateFrame("Frame", nil, UIParent)
-  iconCopy:SetSize(50, 50)
-  iconCopy:SetPoint("CENTER", UIParent, "CENTER")
-  iconCopy:SetFrameStrata("HIGH")
+-- UNIT_SPELLCAST_SUCCEEDED gives us reliable information about spells cast by
+-- the player without needing to parse the combat log.
+SpellFly:RegisterEvent("UNIT_SPELLCAST_SUCCEEDED")
 
-  local icon = iconCopy:CreateTexture(nil, "OVERLAY")
-  icon:SetAllPoints(iconCopy)
-  icon:SetTexture(iconTexture)
+-- Frame pool used to recycle icon frames for better performance and to avoid
+-- creating excessive UI widgets on repeated casts.
+local iconPool = {}
 
-  local animationGroup = iconCopy:CreateAnimationGroup()
+-- Acquire a frame from the pool or create a new one when needed.
+local function AcquireIconFrame()
+  local frame = table.remove(iconPool)
+  if not frame then
+    frame = CreateFrame("Frame", nil, UIParent)
+    frame:SetSize(50, 50)
+    frame:SetFrameStrata("HIGH")
+
+    frame.texture = frame:CreateTexture(nil, "OVERLAY")
+    frame.texture:SetAllPoints(frame)
+  end
+
+  frame:ClearAllPoints()
+  frame:SetPoint("CENTER", UIParent, "CENTER")
+  frame:Show()
+
+  return frame
+end
+
+-- Release a frame back into the pool once its animation finishes.
+local function ReleaseIconFrame(frame)
+  if frame.animationGroup then
+    frame.animationGroup:SetScript("OnFinished", nil)
+    frame.animationGroup:Stop()
+  end
+
+  frame:Hide()
+  frame.texture:SetTexture(nil)
+  table.insert(iconPool, frame)
+end
+
+-- Create and play the flying animation for the provided spellID.
+local function PlaySpellAnimation(spellID)
+  -- Get the icon for this spell.  Some spells may not have a texture, in which
+  -- case we simply abort the animation.
+  local texture = GetSpellTexture(spellID)
+  if not texture then
+    return
+  end
+
+  local iconFrame = AcquireIconFrame()
+  iconFrame.texture:SetTexture(texture)
+
+  local animationGroup = iconFrame:CreateAnimationGroup()
+  iconFrame.animationGroup = animationGroup
+
   local fadeIn = animationGroup:CreateAnimation("Alpha")
   fadeIn:SetFromAlpha(0)
   fadeIn:SetToAlpha(1)
-  fadeIn:SetDuration(0.5)
+  fadeIn:SetDuration(0.2)
 
   local move = animationGroup:CreateAnimation("Translation")
   local direction = math.random(0, 1) == 0 and -1 or 1
-  local xDistance = math.random(200, 800)
-  local yDistance = math.random(-100, 100)
-  move:SetOffset(xDistance * direction, yDistance)
+  move:SetOffset(math.random(200, 800) * direction, math.random(-100, 100))
   move:SetDuration(2)
   move:SetSmoothing("OUT")
 
@@ -33,17 +76,25 @@ local function CreateIconCopy()
   fadeOut:SetStartDelay(1.5)
   fadeOut:SetDuration(0.5)
 
-  animationGroup:SetScript("OnFinished", function() iconCopy:Hide() end)
+  animationGroup:SetScript("OnFinished", function()
+    ReleaseIconFrame(iconFrame)
+  end)
+
   animationGroup:Play()
 end
 
-frame:SetScript("OnEvent", function(self, event, ...)
-  local timestamp, eventType, _, sourceGUID, sourceName, _, _, destGUID, destName, _, _, spellID, spellName = CombatLogGetCurrentEventInfo()
+-- Event handler for UNIT_SPELLCAST_SUCCEEDED. We only care about the player.
+SpellFly:SetScript("OnEvent", function(_, _, unit, _, spellID)
+  if unit ~= "player" then
+    return
+  end
 
-  if eventType == "SPELL_CAST_SUCCESS" and sourceName == UnitName("player") and spellID == spellID then
-    local start, duration, enable = GetSpellCooldown(spellID)
-    cooldownStartTime = GetTime() - start
-    iconTexture = GetSpellTexture(spellID)
-    CreateIconCopy()
+  if spellID then
+    PlaySpellAnimation(spellID)
   end
 end)
+
+-- Random seed for the move offset so different sessions don't start with the
+-- same pattern.  os.time() is sufficient for this simple visual effect.
+math.randomseed(GetTime() * 1000)
+

--- a/SpellFly/SpellFly.toc
+++ b/SpellFly/SpellFly.toc
@@ -1,7 +1,7 @@
-## Interface: 100005
+## Interface: 110107
 ## Title: SpellFly
 ## Notes: Adds a visual effect to player's successful spell casts, making the icons fly off screen.
 ## Author: PantherField
-## Version: 1.0
+## Version: 2.0
 
 SpellFly.lua


### PR DESCRIPTION
## Summary
- modernize SpellFly code to handle UNIT_SPELLCAST_SUCCEEDED
- recycle icon frames for better performance
- new random seeding and animation logic
- update .toc for interface version 110107 and bump addon version

## Testing
- `luacheck SpellFly/SpellFly.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d30895d188328886fb1bbcc7c4698