### PR TITLE
Fix SpellFly TOC icon path and randomize mid screen animations

### DIFF
--- a/SpellFly/SpellFly.lua
+++ b/SpellFly/SpellFly.lua
@@ -137,7 +137,15 @@ local function PlaySpellAnimation(spellID, origin)
   local screenWidth = UIParent:GetWidth()
   local distanceToLeft = startX
   local distanceToRight = screenWidth - startX
-  local direction = distanceToRight < distanceToLeft and 1 or -1
+  local diff = math.abs(distanceToRight - distanceToLeft)
+  local direction
+  if diff <= 5 then
+    -- When near the middle of the screen pick a random direction
+    direction = math.random(0, 1) == 0 and -1 or 1
+  else
+    -- Otherwise prefer the shortest path off screen
+    direction = distanceToRight < distanceToLeft and 1 or -1
+  end
   local horizontalOffset
   if direction == 1 then
     horizontalOffset = distanceToRight + iconFrame:GetWidth()

--- a/SpellFly/SpellFly.toc
+++ b/SpellFly/SpellFly.toc
@@ -1,10 +1,8 @@
 ## Interface: 110107
 ## Title: SpellFly
 ## Notes: Adds a visual effect to player's successful spell casts, making the icons fly off screen.
-## Author: PantherField
+## Author: Renvulf
 ## Version: 2.0
-
-## IconTexture: magifly.tga
+## IconTexture: Interface\AddOns\Spellfly\magifly.tga
 ## SavedVariables: SpellFlyDB
-
 SpellFly.lua


### PR DESCRIPTION
## Summary
- update TOC metadata and icon path
- randomize fly direction when action buttons are near the screen centre

## Testing
- `make test` *(fails: No rule to make target)*
- `luacheck SpellFly/SpellFly.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d4829f00c8328b85883bc5e91c251