### PR TITLE
Improve SpellFly addon stability

### DIFF
--- a/SpellFly/SpellFly.lua
+++ b/SpellFly/SpellFly.lua
@@ -241,11 +241,11 @@ SpellFly:SetScript("OnEvent", function(_, event, ...)
   lastUsedButton = nil
 end)
 
--- Random seed for the move offset so different sessions don't start with the
--- same pattern.  os.time() is sufficient for this simple visual effect.
--- Seed the pseudo random generator if the Lua math library supports it.
-if math and math.randomseed then
-  math.randomseed(GetTime() * 1000)
+-- Seed the random generator using a time-based value to avoid identical
+-- patterns across sessions. `time()` is available in all WoW Lua
+-- environments and provides a reasonably unpredictable seed.
+if math and math.randomseed and time then
+  math.randomseed(time())
 end
 
 -- ---------------------------------------------------------------------
@@ -262,6 +262,7 @@ function SpellFly:ToggleOptions()
     optionsFrame:SetPoint("CENTER")
     optionsFrame:SetMovable(true)
     optionsFrame:EnableMouse(true)
+    optionsFrame:SetClampedToScreen(true)
     optionsFrame:RegisterForDrag("LeftButton")
     optionsFrame:SetScript("OnDragStart", optionsFrame.StartMoving)
     optionsFrame:SetScript("OnDragStop", optionsFrame.StopMovingOrSizing)
@@ -269,6 +270,11 @@ function SpellFly:ToggleOptions()
     optionsFrame.title = optionsFrame:CreateFontString(nil, "OVERLAY", "GameFontNormal")
     optionsFrame.title:SetPoint("CENTER", optionsFrame.TitleBg, "CENTER", 0, 0)
     optionsFrame.title:SetText("SpellFly Options")
+
+    -- Provide a close button and allow the frame to be dismissed with the ESC key
+    optionsFrame.closeButton = CreateFrame("Button", nil, optionsFrame, "UIPanelCloseButton")
+    optionsFrame.closeButton:SetPoint("TOPRIGHT", optionsFrame, "TOPRIGHT", -5, -5)
+    tinsert(UISpecialFrames, optionsFrame:GetName())
 
     -- Checkbox: enable animations from the action bar
     local check1 = CreateFrame("CheckButton", nil, optionsFrame, "ChatConfigCheckButtonTemplate")

--- a/SpellFly/SpellFly.toc
+++ b/SpellFly/SpellFly.toc
@@ -3,6 +3,6 @@
 ## Notes: Adds a visual effect to player's successful spell casts, making the icons fly off screen.
 ## Author: Renvulf
 ## Version: 2.0
-## IconTexture: Interface\AddOns\Spellfly\magifly.tga
+## IconTexture: Interface\AddOns\SpellFly\magifly.tga
 ## SavedVariables: SpellFlyDB
 SpellFly.lua


### PR DESCRIPTION
## Summary
- seed RNG using server time for varied animation offsets
- ensure options frame is clamped to screen and closable via ESC
- fix addon icon path in TOC to match folder name

## Testing
- `luac -p SpellFly/SpellFly.lua` *(fails: command not found)*
- `luajit -b SpellFly/SpellFly.lua /tmp/out.o` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d4b761cd0832888eb3ab892be941f