### PR TITLE
Fix CaptureButtonInfo hook

### DIFF
--- a/SpellFly/SpellFly.lua
+++ b/SpellFly/SpellFly.lua
@@ -92,6 +92,12 @@ local lastOriginInfo -- table with pre-calculated x, y, w, h
 
 -- Forward declare for use in CaptureButtonInfo.
 local GetOriginInfo
+-- Forward declare CaptureButtonInfo so references inside AddButtonToMap are
+-- correctly treated as an upvalue rather than a global. Without this the
+-- OnMouseDown handler would attempt to call a global function which results in
+-- an "attempt to call global 'CaptureButtonInfo'" error when the button is
+-- pressed.
+local CaptureButtonInfo
 
 -- Utility that attempts to find an action button frame for a given action slot.
 -- This relies on the default UI's ActionBarButtonEventsFrame which keeps a list


### PR DESCRIPTION
## Summary
- avoid runtime errors by forward declaring `CaptureButtonInfo`

## Testing
- `luac -p SpellFly.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d5d226730832886e96ecf5452cc7a