### PR TITLE
Improve SpellFly action bar behavior

### DIFF
--- a/SpellFly/SpellFly.lua
+++ b/SpellFly/SpellFly.lua
@@ -88,6 +88,27 @@ local fallbackButtonPatterns = {
   "MultiBar8Button%d",
 }
 
+-- Forward declare AddButtonToMap so functions defined below can reference it.
+-- The actual implementation appears later in the file.
+local AddButtonToMap
+
+-- Utility to scan all UI frames for action buttons. This helps support
+-- third-party action bar addons which may not register their buttons with the
+-- default ActionBarButtonEventsFrame.
+local function EnumerateUnknownActionButtons()
+  if not EnumerateFrames then
+    return
+  end
+
+  local frame = EnumerateFrames()
+  while frame do
+    if frame.action and frame.GetName and frame:IsObjectType("CheckButton") then
+      AddButtonToMap(frame)
+    end
+    frame = EnumerateFrames(frame)
+  end
+end
+
 local lastOriginInfo -- table with pre-calculated x, y, w, h
 
 -- Forward declare for use in CaptureButtonInfo.
@@ -200,6 +221,11 @@ local function HookActionButtons()
       AddButtonToMap(btn)
     end
   end
+
+  -- Additional scan for buttons created by other addons. This call is
+  -- relatively heavy so we restrict it to situations where buttons have
+  -- potentially changed (PLAYER_LOGIN or ACTIONBAR_SLOT_CHANGED).
+  EnumerateUnknownActionButtons()
 end
 
 -- Acquire a frame from the pool or create a new one when needed.
@@ -377,9 +403,18 @@ SpellFly:SetScript("OnEvent", function(_, event, ...)
 
   -- Determine whether any origins are enabled. If none are checked we skip
   -- playing animations entirely.
-  local doBar = SpellFlyDB.offActionBar and lastOriginInfo
+  local doBarRequested = SpellFlyDB.offActionBar
   local doCenter = SpellFlyDB.fromCenter
+
+  -- If the user only enabled action bar animations but we failed to capture a
+  -- valid button (for example a keybind from a hidden bar), fall back to the
+  -- screen centre so an icon still displays.
+  local doBar = doBarRequested and lastOriginInfo
   if not doBar and not doCenter then
+    if doBarRequested then
+      -- Fallback when action bar origin is unavailable
+      PlaySpellAnimation(spellID, nil)
+    end
     lastOriginInfo = nil
     return
   end


### PR DESCRIPTION
## Summary
- enumerate frames to detect action buttons from other addons
- gracefully handle missing action button origin
- fix initialization of AddButtonToMap so action bar animations work

## Testing
- `lua` not available: `bash: lua: command not found`

------
https://chatgpt.com/codex/tasks/task_e_685d63da26088328b14ffbc82d2d5f55