### PR TITLE
Fix animation reuse in SpellFly

### DIFF
--- a/SpellFly/SpellFly.lua
+++ b/SpellFly/SpellFly.lua
@@ -237,6 +237,7 @@ local function AcquireIconFrame()
   local frame = tremove(iconPool)
   if frame then
     if frame.animationGroup then
+      frame.animationGroup:SetScript("OnFinished", nil)
       frame.animationGroup:Stop()
       frame.animationGroup = nil
     end


### PR DESCRIPTION
## Summary
- ensure any previous animation is fully stopped and cleared when reusing an icon frame

## Testing
- `luac -p SpellFly/SpellFly.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e07f8a96c8328ae095941f02e8f13