### PR TITLE
Enable closing options with Escape

### DIFF
--- a/SpellFly/SpellFly.lua
+++ b/SpellFly/SpellFly.lua
@@ -337,6 +337,13 @@ function SpellFly:ToggleOptions()
       UpdateEventRegistration()
     end)
 
+    -- Allow the frame to be closed with the Escape key like other special windows
+    -- by adding it to the global UISpecialFrames list once it has a name.
+    local name = optionsFrame:GetName()
+    if name and UISpecialFrames and not tContains(UISpecialFrames, name) then
+      table.insert(UISpecialFrames, name)
+    end
+
     optionsFrame:Hide()
   end
 


### PR DESCRIPTION
## Summary
- allow options frame to be closed via Escape key

## Testing
- `luac -p SpellFly.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e3396a0f48328aac9264c137a3208