### PR TITLE
Fix color picker hex updates

### DIFF
--- a/Time/Time.lua
+++ b/Time/Time.lua
@@ -1309,6 +1309,15 @@ function frame:CreateSettingsFrame()
       ColorPickerFrame.swatchFunc  = live
       ColorPickerFrame.cancelFunc  = cancel
       ColorPickerFrame.hasOpacity  = false
+      -- When users type a hex code directly and close the picker, the
+      -- regular callback doesn't always fire. Temporarily hook OnHide to
+      -- ensure we apply whatever final color the frame ends with.
+      local prevOnHide = ColorPickerFrame:GetScript("OnHide")
+      ColorPickerFrame:SetScript("OnHide", function(self)
+        live()
+        if prevOnHide then prevOnHide(self) end
+        self:SetScript("OnHide", prevOnHide)
+      end)
       local sw = _G[ColorPickerFrame:GetName().."ColorSwatch"]
       if sw then sw:SetVertexColor(oR,oG,oB) end
       ShowUIPanel(ColorPickerFrame)


### PR DESCRIPTION
## Summary
- ensure manual hex entry applies when closing the color picker

## Testing
- `N/A` (no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_685e59e0dfa88328904e8c8080458037