### PR TITLE
Fix resize handle cursor for Retail compatibility

### DIFF
--- a/FPSMonitor/FPSMonitor.lua
+++ b/FPSMonitor/FPSMonitor.lua
@@ -76,7 +76,8 @@ local function CreateGraphFrame()
         FPSMonitorDB.graph.h = self:GetHeight()
     end)
     -- Resizer handle
-    local sizer = CreateFrame("Frame", nil, graphFrame)
+    -- Use a Button instead of a Frame so SetCursor is available on all clients.
+    local sizer = CreateFrame("Button", nil, graphFrame)
     sizer:SetSize(16, 16)
     sizer:SetPoint("BOTTOMRIGHT")
     sizer:EnableMouse(true)
@@ -88,7 +89,14 @@ local function CreateGraphFrame()
         FPSMonitorDB.graph.w = graphFrame:GetWidth()
         FPSMonitorDB.graph.h = graphFrame:GetHeight()
     end)
-    sizer:SetCursor("SizeNWSE")
+    -- The SetCursor method may not exist on very old clients; fall back to the
+    -- global cursor API in that case.
+    if sizer.SetCursor then
+        sizer:SetCursor("SizeNWSE")
+    else
+        sizer:SetScript("OnEnter", function() SetCursor("SizeNWSE") end)
+        sizer:SetScript("OnLeave", function() ResetCursor() end)
+    end
     graphFrame.sizer = sizer
 
     graphFrame.title = graphFrame:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")


### PR DESCRIPTION
## Summary
- ensure the resize handle uses a Button so `SetCursor` works on all clients
- fallback to the global cursor API if `SetCursor` is unavailable

## Testing
- `luacheck` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68633c35a0dc8328b2465c028ad6cf42