### PR TITLE
Fix UpdateGraph visibility for metric toggles

### DIFF
--- a/FPSMonitor/FPSMonitor.lua
+++ b/FPSMonitor/FPSMonitor.lua
@@ -29,8 +29,10 @@ local math_atan2 = math.atan2
 local math_atan  = math.atan
 local TAU        = math.pi * 2
 
--- forward-declare so closures can see them
-local UpdateGraphConfig, CreateGraphFrame
+-- Forward declare functions referenced before their definitions so
+-- Lua's lexical scoping rules won't cause nil lookups when these
+-- functions are used inside closures.
+local UpdateGraph, UpdateGraphConfig, CreateGraphFrame
 function UpdateGraphConfig()
     graphTimeWindow = FPSMonitorDB.graph.timeWindow or 60
     graphMaxSamples = math_floor(graphTimeWindow / graphUpdateThrottle)


### PR DESCRIPTION
## Summary
- ensure `UpdateGraph` is visible to metric checkbox handlers by forward declaring it

## Testing
- `luacheck --version` *(fails: command not found)*
- `lua -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68635cea8b548328ae95cb2f28eacf8e