### PR TITLE
Add new fonts and adjust UI layout

### DIFF
--- a/FCTF/FCTF.lua
+++ b/FCTF/FCTF.lua
@@ -32,31 +32,40 @@ local COMBAT_FONT_GROUPS = {
     ["Fun"] = {
         path  = ADDON_PATH .. "Fun\\",
         fonts = {
-            "04b.ttf", "Barriecito.ttf", "ComicRunes.ttf", "Green Fuz.otf",
-            "Guroes.ttf", "Melted.ttf", "Midorima.ttf", "Munsteria.ttf",
+            "04b.ttf", "Barriecito.ttf", "ComicRunes.ttf", "Dmagic.ttf",
+            "Elven.ttf", "Green Fuz.otf", "Gunung.ttf", "Guroes.ttf",
+            "Heorot.ttf", "Kiyrand.ttf", "Kting.ttf", "Melted.ttf",
+            "Midorima.ttf", "Munsteria.ttf", "Odinson.ttf", "Pau.ttf",
             "Runic.ttf", "Runy.ttf", "Shiruken.ttf", "Skullphabet.ttf",
-            "WhoAsksSatan.ttf", "Wickedmouse.ttf", "akash.ttf", "edgyh.ttf",
-            "edkies.ttf", "graff.ttf", "shog.ttf",
+            "WKnight.ttf", "Wasser.ttf", "WhoAsksSatan.ttf", "Wickedmouse.ttf",
+            "akash.ttf", "crygords.ttf", "edgyh.ttf", "edkies.ttf",
+            "figtoen.ttf", "graff.ttf", "leviathans.ttf", "shog.ttf",
+            "tsuchigumo.ttf",
         },
     },
     ["Future"] = {
         path  = ADDON_PATH .. "Future\\",
         fonts = {
-            "914Solid.ttf", "ChopSic.ttf", "Digital.ttf", "FastHand.ttf",
-            "Orbitron.ttf", "Pepsi.ttf", "RaceSpace.ttf", "RushDriver.ttf",
+            "914Solid.ttf", "Audiowide.ttf", "Caesar.ttf", "ChopSic.ttf",
+            "Digital.ttf", "FastHand.ttf", "Orbitron.ttf", "Pepsi.ttf",
+            "Price.ttf", "RaceSpace.ttf", "RushDriver.ttf", "albra.TTF",
         },
     },
     ["Movie/Game"] = {
         path  = ADDON_PATH .. "MovieGame\\",
         fonts = {
-            "Deltarune.ttf", "Halo.ttf", "HarryP.ttf", "Pokemon.ttf",
-            "Spongebob.ttf", "Terminator.ttf", "modernwarfare.ttf",
+            "Acadian.ttf", "Deltarune.ttf", "Elven.ttf", "Gunung.ttf",
+            "Halo.ttf", "HarryP.ttf", "Hobbit.ttf", "Kting.ttf",
+            "Ktingw.ttf", "MetalMacabre.ttf", "Odinson.ttf", "Pokemon.ttf",
+            "Ruritania.ttf", "Spongebob.ttf", "Terminator.ttf",
+            "The Centurion .ttf", "VTKS.ttf", "dalek.ttf",
+            "modernwarfare.ttf",
         },
     },
     ["Easy-to-Read"] = {
         path  = ADDON_PATH .. "Easy-to-Read\\",
         fonts = {
-            "AlteHaasGroteskBold.ttf", "Expressway.ttf",
+            "AlteHaasGroteskBold.ttf", "Bangers.ttf", "Expressway.ttf",
             "NotoSans_Condensed-Bold.ttf", "PTSansNarrow-Bold.ttf",
             "Prototype.ttf", "Roboto-Bold.ttf", "SF-Pro.ttf",
             "accidentalpres.ttf", "bignoodletitling.ttf", "continuum.ttf",
@@ -237,10 +246,11 @@ end
 -- 5) SCALE SLIDER -----------------------------------------------------------
 local scaleLabel = frame:CreateFontString(nil, "OVERLAY", "GameFontNormal")
 -- position the label below the last dropdown to prevent overlap
+local sliderOffsetX = 15 -- shift controls slightly right for centering
 if lastDropdown then
-    scaleLabel:SetPoint("TOPLEFT", lastDropdown, "BOTTOMLEFT", 0, -20)
+    scaleLabel:SetPoint("TOPLEFT", lastDropdown, "BOTTOMLEFT", sliderOffsetX, -20)
 else
-    scaleLabel:SetPoint("TOPLEFT", frame, "TOPLEFT", 16, -160)
+    scaleLabel:SetPoint("TOPLEFT", frame, "TOPLEFT", 16 + sliderOffsetX, -160)
 end
 scaleLabel:SetText("Combat Text Size:")
 


### PR DESCRIPTION
## Summary
- include all fonts from addon directories for selection
- shift combat text size slider and preview edit box slightly right for better centering

## Testing
- `luac -p FCTF.lua` *(fails: command not found)*
- `lua -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68665cde89648328a5f02979be6fa6eb