### PR TITLE
Fix combat text font selection

### DIFF
--- a/FCTF/FCTF.lua
+++ b/FCTF/FCTF.lua
@@ -330,7 +330,14 @@ applyBtn:SetPoint("BOTTOMLEFT", 16, 16)
 applyBtn:SetText("Apply")
 applyBtn:SetScript("OnClick", function()
     if FCTFDB.selectedFont then
-        DAMAGE_TEXT_FONT = ADDON_PATH .. FCTFDB.selectedFont
+        -- Update Blizzard's Floating Combat Text font reference
+        SetCVar("floatingCombatTextFont", ADDON_PATH .. FCTFDB.selectedFont)
+        -- force a refresh for immediately visible changes
+        if CombatText_UpdateDisplayedMessages then
+            CombatText_UpdateDisplayedMessages()
+        end
+        -- also assign the global for builds that still honour it
+        COMBAT_TEXT_FONT = ADDON_PATH .. FCTFDB.selectedFont
         print("|cFF00FF00[FCTF]|r Combat font saved. Restart WoW to apply.")
         UIErrorsFrame:AddMessage("FCTF: please EXIT & RESTART WoW to apply.",1,1,0)
     else
@@ -450,7 +457,12 @@ frame:SetScript("OnEvent", function(self, event, name)
         if FCTFDB.selectedFont then
             local g,f = FCTFDB.selectedFont:match("^([^/]+)/(.+)$")
             if g and f and dropdowns[g] and existsFonts[g] and existsFonts[g][f] then
-                DAMAGE_TEXT_FONT = ADDON_PATH .. FCTFDB.selectedFont
+                -- apply saved font on load
+                SetCVar("floatingCombatTextFont", ADDON_PATH .. FCTFDB.selectedFont)
+                if CombatText_UpdateDisplayedMessages then
+                    CombatText_UpdateDisplayedMessages()
+                end
+                COMBAT_TEXT_FONT = ADDON_PATH .. FCTFDB.selectedFont
                 local cache = cachedFonts[g] and cachedFonts[g][f]
                 if cache then SetPreviewFont(cache) end
                 preview:SetText(editBox:GetText())


### PR DESCRIPTION
## Summary
- fix combat text font to use the correct CVar and global
- refresh combat text when applying or loading

## Testing
- `luac -p FCTF/FCTF.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68667964b6bc8328bc404fd25cb30467