### PR TITLE
Fix combat text font update and save settings

### DIFF
--- a/FCTF/FCTF.lua
+++ b/FCTF/FCTF.lua
@@ -330,9 +330,11 @@ applyBtn:SetPoint("BOTTOMLEFT", 16, 16)
 applyBtn:SetText("Apply")
 applyBtn:SetScript("OnClick", function()
     if FCTFDB.selectedFont then
-        DAMAGE_TEXT_FONT = ADDON_PATH .. FCTFDB.selectedFont
-        print("|cFF00FF00[FCTF]|r Combat font saved. Restart WoW to apply.")
-        UIErrorsFrame:AddMessage("FCTF: please EXIT & RESTART WoW to apply.",1,1,0)
+        local fontPath = ADDON_PATH .. FCTFDB.selectedFont
+        DAMAGE_TEXT_FONT = fontPath
+        COMBAT_TEXT_FONT  = fontPath
+        print("|cFF00FF00[FCTF]|r Combat font saved. You can now /reload to apply.")
+        UIErrorsFrame:AddMessage("FCTF: please /reload UI to apply.",1,1,0)
     else
         print("|cFFFF0000[FCTF]|r No font selected.")
     end
@@ -450,7 +452,9 @@ frame:SetScript("OnEvent", function(self, event, name)
         if FCTFDB.selectedFont then
             local g,f = FCTFDB.selectedFont:match("^([^/]+)/(.+)$")
             if g and f and dropdowns[g] and existsFonts[g] and existsFonts[g][f] then
-                DAMAGE_TEXT_FONT = ADDON_PATH .. FCTFDB.selectedFont
+                local fontPath = ADDON_PATH .. FCTFDB.selectedFont
+                DAMAGE_TEXT_FONT = fontPath
+                COMBAT_TEXT_FONT  = fontPath
                 local cache = cachedFonts[g] and cachedFonts[g][f]
                 if cache then SetPreviewFont(cache) end
                 preview:SetText(editBox:GetText())

--- a/FCTF/FCTF.toc
+++ b/FCTF/FCTF.toc
@@ -5,5 +5,6 @@
 ## Author: Renvulf
 ## Version: 1.5
 ## SavedVariables: FCTFDB
+## SavedVariablesPerCharacter: FCTFPCDB
 
 FCTF.lua


### PR DESCRIPTION
## Summary
- sync combat text font globals when applying new fonts
- update instructions to reload rather than restart
- save per-character settings by adding FCTFPCDB to saved variables

## Testing
- `luac -p FCTF/FCTF.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68669040530c8328a7f52853366391f5