### PR TITLE
Fix nil COMBAT_TEXT_TYPE_INFO at startup

### DIFF
--- a/FCTF/FCTF.lua
+++ b/FCTF/FCTF.lua
@@ -118,10 +118,14 @@ for group, data in pairs(COMBAT_FONT_GROUPS) do
     end
 end
 
--- snapshot Blizzard's default handlers so we can restore them
 local originalInfo = {}
-for k, v in pairs(COMBAT_TEXT_TYPE_INFO) do
-    originalInfo[k] = v
+-- COMBAT_TEXT_TYPE_INFO may not exist yet at load time. Guard the copy loop
+-- so "pairs" only runs when the table is available to avoid nil-table errors
+-- during addon initialization.
+if type(COMBAT_TEXT_TYPE_INFO) == "table" then
+    for k, v in pairs(COMBAT_TEXT_TYPE_INFO) do
+        originalInfo[k] = v
+    end
 end
 
 -- 2) MAIN WINDOW


### PR DESCRIPTION
## Summary
- prevent crash when `COMBAT_TEXT_TYPE_INFO` is nil at load time

## Testing
- `luac -p FCTF/FCTF.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b325242d083289f866b8f3bdb2115