### PR TITLE
Fix layout spacing

### DIFF
--- a/FCTF/FCTF.lua
+++ b/FCTF/FCTF.lua
@@ -126,7 +126,7 @@ local frame = CreateFrame("Frame", addonName .. "Frame", UIParent, "BackdropTemp
 -- Shrink the overall height so the bottom border sits just
 -- beneath the Apply/Default/Close buttons. The exact value
 -- may be tweaked as needed; 360 provides a snug fit.
-frame:SetSize(420, 440)
+frame:SetSize(420, 472)
 frame:SetPoint("CENTER")
 frame:SetBackdrop({
     bgFile   = "Interface\\DialogFrame\\UI-DialogBox-Background",
@@ -384,7 +384,7 @@ cbIncHeal:SetPoint("TOPLEFT", editBox, "BOTTOMLEFT", baseX + 200, baseY)
 -- 8) APPLY & DEFAULT BUTTONS -----------------------------------------------
 local applyBtn = CreateFrame("Button", nil, frame, "UIPanelButtonTemplate")
 applyBtn:SetSize(120, 22)
-applyBtn:SetPoint("BOTTOMLEFT", 16, 16)
+applyBtn:SetPoint("BOTTOMLEFT", 16, 8)
 applyBtn:SetText("Apply")
 applyBtn:SetScript("OnClick", function()
     if FCTFDB.selectedFont then
@@ -431,7 +431,7 @@ end)
 -- 11) CLOSE BUTTON
 local closeBtn = CreateFrame("Button", nil, frame, "UIPanelButtonTemplate")
 closeBtn:SetSize(80, 24)
-closeBtn:SetPoint("BOTTOMRIGHT", -16, 16)
+closeBtn:SetPoint("BOTTOMRIGHT", -16, 8)
 closeBtn:SetText("Close")
 closeBtn:SetScript("OnClick", function() frame:Hide() end)
 closeBtn:SetScript("OnEnter", function(self)


### PR DESCRIPTION
## Summary
- fix the layout for the FCTF configuration window so bottom buttons fit correctly

## Testing
- `lua -v` *(fails: command not found)*
- `luac -p FCTF/FCTF.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b45c027848328bc97fb842109ade7