### PR TITLE
Fix dropdown width retrieval

### DIFF
--- a/FCTF/FCTF.lua
+++ b/FCTF/FCTF.lua
@@ -253,7 +253,11 @@ for idx, grp in ipairs(order) do
     -- position label so its left edge aligns with the dropdown
     label:ClearAllPoints()
     label:SetPoint("BOTTOM", dd, "TOP", 0, 3)
-    label:SetWidth(UIDropDownMenu_GetWidth(dd))
+    -- Use the frame's GetWidth() method to obtain the dropdown width.
+    -- UIDropDownMenu_GetWidth has been removed in Dragonflight and older
+    -- globals may not return a valid number. GetWidth() is available on all
+    -- frames and ensures a numeric width is returned.
+    label:SetWidth(dd:GetWidth())
     label:SetJustifyH("CENTER")
     label:SetText(grp)
 


### PR DESCRIPTION
## Summary
- use Frame:GetWidth() when setting dropdown label width

## Testing
- `luac -p FCTF/FCTF.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bc21130d883288c3a7f3fefdfbcaf