### PR TITLE
Improve addon compatibility across WoW versions

### DIFF
--- a/addonoverhaul/FontMagicCustomFonts/FontMagicCustomFonts.lua
+++ b/addonoverhaul/FontMagicCustomFonts/FontMagicCustomFonts.lua
@@ -4,6 +4,17 @@
 -- FontMagic will be able to use them.
 
 local ADDON_NAME = ...
+
+-- safe loader: C_AddOns.LoadAddOn (Retail ≥11.0.2) or legacy LoadAddOn
+local safeLoadAddOn
+if type(C_AddOns) == "table" and type(C_AddOns.LoadAddOn) == "function" then
+    safeLoadAddOn = C_AddOns.LoadAddOn
+elseif type(LoadAddOn) == "function" then
+    safeLoadAddOn = LoadAddOn
+else
+    safeLoadAddOn = function() end
+end
+
 local ADDON_PATH = "Interface\\AddOns\\" .. ADDON_NAME .. "\\Custom\\"
 
 -- Public table used by the main FontMagic addon


### PR DESCRIPTION
## Summary
- add a safe `LoadAddOn` wrapper in both addons
- replace direct `LoadAddOn` call with the safe wrapper
- guard `WorldTextScale` slider with version check and disable when unsupported

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6874d47b84fc8328b0df858cc0595ab7