### PR TITLE
Fix Lua syntax error

### DIFF
--- a/DiceTracker/DiceTracker.lua
+++ b/DiceTracker/DiceTracker.lua
@@ -1524,8 +1524,6 @@ processRollPair = function(player, roll1, roll2)
     DiceTrackerDB.stats.lastPrediction, DiceTrackerDB.stats.lastPredictionConfidence = addonTable:Predict()
     maybeUpdateUI()
 end
-
-end
 local frame = CreateFrame("Frame")
 frame:RegisterEvent("ADDON_LOADED")
 frame:RegisterEvent("PLAYER_LOGOUT")


### PR DESCRIPTION
## Summary
- remove stray `end` in DiceTracker.lua causing 'near <eof>' error

## Testing
- `luac` not available; no tests run

------
https://chatgpt.com/codex/tasks/task_e_6876fe2b6ddc8328866d58254de865e3