### PR TITLE
Implement proper saved variable usage

### DIFF
--- a/DiceTracker/DiceTracker.lua
+++ b/DiceTracker/DiceTracker.lua
@@ -309,7 +309,8 @@ local function scheduleSave()
         addonTable.saveTicker = C_Timer.NewTicker(1, function()
             if DiceTrackerDB then
                 DiceTrackerDB.isDirty = false
-                SavedVariables["DiceTrackerDB"] = DiceTrackerDB
+                -- Persist data using the existing saveAddonData helper
+                saveAddonData()
             end
             addonTable.saveTicker:Cancel()
             addonTable.saveTicker = nil

--- a/DiceTracker/DiceTracker.toc
+++ b/DiceTracker/DiceTracker.toc
@@ -3,5 +3,5 @@
 ## Notes: A neural network-based dice outcome predictor.
 ## Author: SevenGod
 ## Version: 1.0
-## SavedVariables: DiceTrackerDB
+## SavedVariables: DiceTrackerDB, DiceTrackerSavedVariables
 DiceTracker.lua


### PR DESCRIPTION
## Summary
- store an additional saved variable `DiceTrackerSavedVariables`
- write addon data using `saveAddonData()` instead of a missing `SavedVariables` table

## Testing
- `apt-get update` *(fails: internet disabled)*

------
https://chatgpt.com/codex/tasks/task_e_68770bba7b98832891021ca234d2597d