### PR TITLE
Improve disenchant automation

### DIFF
--- a/EnchantBuddy/EnchantBuddy.toc
+++ b/EnchantBuddy/EnchantBuddy.toc
@@ -1,4 +1,4 @@
-## Interface: 90205
+## Interface: 100207
 ## Title: EnchantBuddy
 ## Notes: Spam a key to sequentially disenchant items in your inventory.
 ## Author: ChatGPT


### PR DESCRIPTION
## Summary
- iterate through bags more efficiently and remember position
- warn if Disenchant isn't known
- clear the cursor before disenchanting
- allow clearing bindings via options panel
- update Interface version for retail WoW

## Testing
- `luacheck` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68833b7120a88328aa491a84bc965ce4