### PR TITLE
Fix EnchantBuddy key binding init

### DIFF
--- a/EnchantBuddy/EnchantBuddy.xml
+++ b/EnchantBuddy/EnchantBuddy.xml
@@ -1,5 +1,4 @@
 <Ui xmlns="http://www.blizzard.com/wow/ui/">
-  <Script file="EnchantBuddy.lua"/>
 
   <Frame name="EnchantBuddyButton" hidden="true" inherits="SecureActionButtonTemplate">
     <Size x="1" y="1"/>


### PR DESCRIPTION
## Summary
- ensure XML loads before Lua
- delay button reference until ADDON_LOADED
- validate bindings and guard against nil
- scan bank bags as well as inventory

## Testing
- `luac -p EnchantBuddy/EnchantBuddy.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68833f525c688328bfb42d4034491781