### PR TITLE
Fix EnchantBuddy binding issues

### DIFF
--- a/EnchantBuddy/EnchantBuddy.toc
+++ b/EnchantBuddy/EnchantBuddy.toc
@@ -1,6 +1,6 @@
 ## Interface: 100207
 ## Title: EnchantBuddy
-## Notes: Spam a key to sequentially disenchant items in your inventory.
+## Notes: Spam a key to sequentially disenchant items in your inventory. Use /reload after changing your key.
 ## Author: ChatGPT
 ## Version: 1.0
 ## SavedVariables: EnchantBuddyDB

--- a/EnchantBuddy/EnchantBuddy.xml
+++ b/EnchantBuddy/EnchantBuddy.xml
@@ -9,9 +9,4 @@
     </Scripts>
   </Frame>
 
-  <Bindings>
-    <Binding name="CLICK EnchantBuddyButton:LeftButton" header="EnchantBuddy">
-      Disenchant Next Item
-    </Binding>
-  </Bindings>
 </Ui>


### PR DESCRIPTION
## Summary
- remove unused XML binding block
- prevent bank bag scanning and reset search pointer after wrap
- sanitize custom key binding and persist it properly
- delay InterfaceOptions registration until available
- document the need to `/reload` when changing key

## Testing
- `apt-get update` *(fails: internet disabled)*
- `luacheck EnchantBuddy.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68834134c1fc83289883e27a0162ba84