### PR TITLE
Fix option loading for EnchantBuddy

### DIFF
--- a/EnchantBuddy/EnchantBuddy.toc
+++ b/EnchantBuddy/EnchantBuddy.toc
@@ -1,7 +1,5 @@
 ## Interface: 90205
 ## Title: EnchantBuddy
-## X-LoadOn: PLAYER_LOGIN
-## Dependencies: Blizzard_InterfaceOptions
 ## Notes: Disenchant items sequentially with a single key.
 ## SavedVariables: EnchantBuddyDB
 


### PR DESCRIPTION
## Summary
- clean up EnchantBuddy.toc to rely on Blizzard loading

## Testing
- `luac -p EnchantBuddy/EnchantBuddy.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68836e3d978883288e01c0389bf05818