### PR TITLE
Fix Interface Options loading and improve item scan

### DIFF
--- a/EnchantBuddy/EnchantBuddy.toc
+++ b/EnchantBuddy/EnchantBuddy.toc
@@ -1,6 +1,7 @@
-## Interface: 90205
+## Interface: 100075
 ## Title: EnchantBuddy
 ## Notes: Disenchant items sequentially with a single key.
 ## SavedVariables: EnchantBuddyDB
+## OptionalDeps: Blizzard_Options
 
 EnchantBuddy.lua


### PR DESCRIPTION
## Summary
- bump interface version
- load Blizzard_Options before addon for Interface API access
- check for InterfaceOptions API before using
- use C_Item API to verify disenchantable items
- localize globals for faster lookups

## Testing
- `lua -p EnchantBuddy.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688381cc778c8328a558e09d4f8641fe