### PR TITLE
Improve pre-click error handling

### DIFF
--- a/EnchantBuddy/EnchantBuddy.lua
+++ b/EnchantBuddy/EnchantBuddy.lua
@@ -89,13 +89,16 @@ end
 
 -- runs inside the secure context, before each click
 function EnchantBuddy_PreClick(self)
-  if _UnitCasting("player") or _UnitChannel("player") then return end
+  if _UnitCasting("player") or _UnitChannel("player") then
+    self:SetAttribute("macrotext1", "/run print('EnchantBuddy: casting in progress.')")
+    return
+  end
   if not _IsSpellKnown(DISENCHANT_SPELL_ID, true) then
-    print("EnchantBuddy: Disenchant spell not known.")
+    self:SetAttribute("macrotext1", "/run print('EnchantBuddy: Disenchant spell not known.')")
     return
   end
   if _CursorHasItem() then
-    print("EnchantBuddy: clear your cursor before pressing the key.")
+    self:SetAttribute("macrotext1", "/run print('EnchantBuddy: clear your cursor before pressing the key.')")
     return
   end
 


### PR DESCRIPTION
## Summary
- set safe macrotext when a disenchant attempt can't proceed

## Testing
- `luacheck EnchantBuddy/EnchantBuddy.lua` *(fails: command not found)*
- `lua -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68842a3462f88328a863bf2f52701f8e