### PR TITLE
Fix interface options loader for EnchantBuddy

### DIFF
--- a/EnchantBuddy/EnchantBuddy.lua
+++ b/EnchantBuddy/EnchantBuddy.lua
@@ -25,10 +25,13 @@ local _GetSpellInfo = C_Spell.GetSpellInfo
 local _GetSpellTexture = C_Spell.GetSpellTexture
 
 -- ensure the Blizzard options UI is available without external dependencies
+-- ensure the Blizzard Interface Options UI code is loaded so the panel APIs are available
 local function EnsureOptionsLoaded()
   if not InterfaceOptionsFrame or not InterfaceOptions_AddCategory or not InterfaceOptionsFrame_OpenToCategory then
-    -- load the built-in options addon if it isn't already
-    pcall(UIParentLoadAddOn, "Blizzard_Options")
+    -- load the real Blizzard Interface Options addon
+    pcall(UIParentLoadAddOn, "Blizzard_InterfaceOptions")
+    -- also load the settings UI (if panels are ever moved there)
+    pcall(UIParentLoadAddOn, "Blizzard_Settings")
   end
 end
 

--- a/EnchantBuddy/EnchantBuddy.toc
+++ b/EnchantBuddy/EnchantBuddy.toc
@@ -2,5 +2,6 @@
 ## Title: EnchantBuddy
 ## Notes: Disenchant items sequentially with a single key.
 ## SavedVariables: EnchantBuddyDB
+## OptionalDeps: Blizzard_InterfaceOptions
 
 EnchantBuddy.lua


### PR DESCRIPTION
## Summary
- load Blizzard_InterfaceOptions instead of Blizzard_Options
- mark Blizzard_InterfaceOptions as an optional dependency

## Testing
- `sudo apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_688441f0c0cc8328860eeec4c3fcb0d4