### PR TITLE
Refactor options UI to standalone frame

### DIFF
--- a/EnchantBuddy/EnchantBuddy.toc
+++ b/EnchantBuddy/EnchantBuddy.toc
@@ -2,6 +2,5 @@
 ## Title: EnchantBuddy
 ## Notes: Disenchant items sequentially with a single key.
 ## SavedVariables: EnchantBuddyDB
-## OptionalDeps: Blizzard_InterfaceOptions
 
 EnchantBuddy.lua


### PR DESCRIPTION
## Summary
- remove Blizzard options dependencies
- add standalone options window with custom key binding buttons
- update slash command to show the new window
- initialize the custom UI on login

## Testing
- `lua -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68844716c3988328873d474b03f11848