### PR TITLE
Implement slash command macro creation

### DIFF
--- a/EnchantBuddy/EnchantBuddy.lua
+++ b/EnchantBuddy/EnchantBuddy.lua
@@ -244,6 +244,7 @@ SlashCmdList.ENCHANTBUDDY = function()
   CreateCustomOptions()
   customOptions:Show()
   customOptions:refresh()
+  EnsureMacro()
 end
 
 -- event handling


### PR DESCRIPTION
## Summary
- ensure `/enchantbuddy` creates the macro if it was missing

## Testing
- `luacheck EnchantBuddy/EnchantBuddy.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884606ea5788328961f2c414fe96a25