### PR TITLE
Fix refresh & tooltips in DisenchantBuddy

### DIFF
--- a/DisenchantBuddy/DisenchantBuddy.lua
+++ b/DisenchantBuddy/DisenchantBuddy.lua
@@ -31,6 +31,8 @@ local itemList = {}
 local nonDE = {}
 local pendingLoad = {}
 local refreshQueued = false
+-- Forward declaration so functions defined earlier can reference it
+local RefreshList
 
 -- Non-disenchantable items list
 nonDE = {
@@ -391,6 +393,18 @@ local function CreateRow(parent, index)
         end
         ScanBags()
         parent:Refresh()
+    end)
+
+    -- Show item tooltip on hover similar to TSM's destroying list
+    row:SetScript("OnEnter", function(self)
+        if self.data and self.data.link then
+            GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
+            GameTooltip:SetHyperlink(self.data.link)
+            GameTooltip:Show()
+        end
+    end)
+    row:SetScript("OnLeave", function()
+        GameTooltip:Hide()
     end)
 
     function row:SetData(data)


### PR DESCRIPTION
## Summary
- avoid global lookup of `RefreshList` which caused runtime errors
- show item tooltips when hovering items in the list

## Testing
- `apt-get update` *(fails: repository access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6885f9aa1cfc83289c286dfba5ed5176