### PR TITLE
Fix DisenchantBuddy macro

### DIFF
--- a/DisenchantBuddy/DisenchantBuddy.lua
+++ b/DisenchantBuddy/DisenchantBuddy.lua
@@ -516,7 +516,9 @@ local function CreateUI()
     disenchantBtn:SetScript("PreClick", function(btn)
         local data = scroll.selected
         if data then
-            btn:SetAttribute("macrotext", string.format("/cast Disenchant\n/use %d %d", data.bag, data.slot))
+            -- Use the localized spell name like TSM so the macro works on all clients
+            local deName = GetSpellInfo(13262) or "Disenchant"
+            btn:SetAttribute("macrotext", string.format("/cast %s;\n/use %d %d", deName, data.bag, data.slot))
             -- Start monitoring the disenchant process before the cast so we
             -- can refresh the UI once it completes or fails.
             StartDestroy()


### PR DESCRIPTION
## Summary
- make DisenchantBuddy use localized spell name for disenchant macro

## Testing
- `luac -p DisenchantBuddy/DisenchantBuddy.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885fe87de18832886f03a5183228a69