### PR TITLE
Fix DisenchantBuddy macro availability

### DIFF
--- a/DisenchantBuddy/DisenchantBuddy.lua
+++ b/DisenchantBuddy/DisenchantBuddy.lua
@@ -949,6 +949,13 @@ optionsLoader:RegisterEvent("ADDON_LOADED")
 optionsLoader:SetScript("OnEvent", function(self, addon)
     if addon == ADDON_NAME then
         CreateOptions()
+        -- Create the UI so the secure destroy button exists even if the
+        -- window is never manually opened. This allows the user macro to work
+        -- immediately on login just like TSM's implementation.
+        local ok, err = pcall(CreateUI)
+        if not ok and err then
+            print("DisenchantBuddy error:", err)
+        end
         EnsureMacro()
         self:UnregisterEvent("ADDON_LOADED")
     end


### PR DESCRIPTION
## Summary
- initialize DisenchantBuddy's UI during addon load
- create the secure destroy button on login
- keep macro available even if window was never opened

## Testing
- `luac -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886e5824e808328a86ca0e0a8bb6453