### PR TITLE
Improve Disenchant Buddy macro initialization

### DIFF
--- a/DisenchantBuddy/DisenchantBuddy.lua
+++ b/DisenchantBuddy/DisenchantBuddy.lua
@@ -1003,3 +1003,17 @@ optionsLoader:SetScript("OnEvent", function(self, addon)
         self:UnregisterEvent("ADDON_LOADED")
     end
 end)
+
+-- Build the main UI on login so the secure proxy button exists even if the
+-- window is never manually opened. This ensures the user macro can fire the
+-- "Disenchant Next" logic immediately after logging in.
+local initLoader = CreateFrame("Frame")
+initLoader:RegisterEvent("PLAYER_LOGIN")
+initLoader:SetScript("OnEvent", function()
+    if not frame then
+        local ok, err = pcall(CreateUI)
+        if not ok and err then
+            print("DisenchantBuddy error:", err)
+        end
+    end
+end)


### PR DESCRIPTION
## Summary
- automatically create DisenchantBuddy's UI at login so the hidden macro proxy is available immediately
- keep retail spell icon retrieval using `C_Spell.GetSpellInfo`

## Testing
- `lua -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688767caf0208328974b79cb9cfacfc0