### PR TITLE
Fix trinket evaluation and add optional trinket equips

### DIFF
--- a/Smartbot/Smartbot.toc
+++ b/Smartbot/Smartbot.toc
@@ -2,7 +2,7 @@
 ## Title: Smartbot
 ## Notes: Auto equips upgrades based on custom stat weights.
 ## Author: OpenAI
-## Version: 1.0
+## Version: 1.1
 ## SavedVariables: SmartbotDB
 
 Smartbot.lua


### PR DESCRIPTION
## Summary
- Handle missing GetItemStats API and gracefully evaluate item stats
- Add optional "Include trinkets" setting and related bag-scan logic
- Bump addon version to 1.1

## Testing
- `luac -p Smartbot/Smartbot.lua` *(fails: command not found: luac)*

------
https://chatgpt.com/codex/tasks/task_e_68b3eb93bedc832893ea36e7c8b563b7