### PR TITLE
Add DPS stat weight and persist Smartbot settings

### DIFF
--- a/Smartbot/Smartbot.toc
+++ b/Smartbot/Smartbot.toc
@@ -3,6 +3,6 @@
 ## Notes: Auto equips upgrades based on custom stat weights.
 ## Author: OpenAI
 ## Version: 1.1
-## SavedVariables: SmartbotDB
+## SavedVariablesPerCharacter: SmartbotDB
 
 Smartbot.lua


### PR DESCRIPTION
## Summary
- support Damage Per Second in stat weights
- persist per-specialization weights and hide irrelevant primary stats in options panel
- only scan bags for upgrades when non-zero weights are defined and save data per character

## Testing
- `lua -p Smartbot/Smartbot.lua` *(command not found: lua)*
- `apt-get update` *(403 Forbidden when attempting to install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b3ef51ca648328b0b34f0010e5d023