### PR TITLE
Add minimap button and advanced stat options

### DIFF
--- a/Smartbot/Smartbot.toc
+++ b/Smartbot/Smartbot.toc
@@ -2,7 +2,7 @@
 ## Title: Smartbot
 ## Notes: Auto equips upgrades based on custom stat weights.
 ## Author: OpenAI
-## Version: 1.1
+## Version: 1.2
 ## SavedVariablesPerCharacter: SmartbotDB
 
 Smartbot.lua


### PR DESCRIPTION
## Summary
- add draggable minimap button that opens the Smartbot configuration
- persist "show all stats" option and minimap location in saved variables
- scan bags for upgrades even if all stat weights are zero

## Testing
- `apt-get update` *(fails: repository not signed)*


------
https://chatgpt.com/codex/tasks/task_e_68b3f429a7408328999d687b89ed729c