### PR TITLE
Fix tooltip hooks and auto-equip logic

### DIFF
--- a/Smartbot/Smartbot.toc
+++ b/Smartbot/Smartbot.toc
@@ -1,4 +1,4 @@
-## Interface: 100207
+## Interface: 110200
 ## Title: Smartbot
 ## Notes: Auto equips upgrades based on custom stat weights.
 ## Author: OpenAI


### PR DESCRIPTION
## Summary
- Hook item tooltips via TooltipDataProcessor and legacy fallbacks, fixing Retail errors
- Enhance bag scanning with item data caching, multi-slot selection, and manual force scans
- Improve minimap button dragging and update TOC for 11.2 clients

## Testing
- `luac -p Smartbot/Smartbot.lua` *(fails: command not found)*
- `luacheck Smartbot/Smartbot.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b41219a9d48328af1d9620bb747c68