### PR TITLE
chore: add Lua test CI and runner

### DIFF
--- a/.github/workflows/lua-tests.yml
+++ b/.github/workflows/lua-tests.yml
@@ -1,0 +1,51 @@
+name: Lua Tests
+on:
+  push:
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Install Lua 5.1 for pure-Lua tests/specs
+      - uses: leafo/gh-actions-lua@v10
+        with:
+          luaVersion: "5.1"
+
+      - name: Show Lua version
+        run: lua -v
+
+      - name: Discover *_spec.lua files
+        id: discover
+        shell: bash
+        run: |
+          set -e
+          specs="$(git ls-files '*_spec.lua' || true)"
+          if [ -z "$specs" ]; then
+            echo "No *_spec.lua files found. Failing to surface misconfiguration." >&2
+            exit 1
+          fi
+          printf '%s\n' "$specs" > _spec_list.txt
+          echo "found=$(wc -l < _spec_list.txt | tr -d ' ')" >> $GITHUB_OUTPUT
+          echo "Discovered specs:"; cat _spec_list.txt
+
+      - name: Run specs
+        if: steps.discover.outcomes != 'failure'
+        shell: bash
+        run: |
+          set -e
+          while IFS= read -r s; do
+            echo "::group::Running $s"
+            lua "$s"
+            echo "::endgroup::"
+          done < _spec_list.txt
+
+      - name: Upload spec list (debug)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lua-spec-list
+          path: _spec_list.txt

--- a/.smartbot/STATUS.json
+++ b/.smartbot/STATUS.json
@@ -1,11 +1,36 @@
 {
   "schema": 1,
   "completed": {
-    "stages": [1,2,3,4,5,6,7,8],
-    "refinements": ["R1","R2","R3","R4","R5","R6","R7","R8","R9","R10"],
+    "stages": [
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8
+    ],
+    "refinements": [
+      "R1",
+      "R2",
+      "R3",
+      "R4",
+      "R5",
+      "R6",
+      "R7",
+      "R8",
+      "R9",
+      "R10"
+    ],
     "health_ok": false
   },
   "open_issues": null,
-  "last_commit": "1023b1fdad5ecaddf52a721907c0ac73d7fed4a9",
-  "timestamp_utc": "2025-09-04T06:05:05Z"
+  "last_commit": "baa03c47a009883a9c5d22cfb4cf38fc9301ed29",
+  "timestamp_utc": "2025-09-04T06:23:35Z",
+  "ci": {
+    "workflow": "lua-tests.yml",
+    "status": "unknown",
+    "last_run": null
+  }
 }

--- a/BLOCKERS.md
+++ b/BLOCKERS.md
@@ -10,3 +10,4 @@
   - Error: `E: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed.` and other 403 Forbidden errors.
   - Files: tests/*, Smartbot/Smartbot.lua
   - Next steps: Fix apt repository access or provide pre-installed Lua interpreter to run tests and /sb learn health.
+- Another attempt to install Lua via apt-get update failed with 403 Forbidden, leaving tests unrun.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -24,3 +24,4 @@ DONE_REFINE:R10 - Added developer health check command. (Smartbot/Smartbot.lua)
 GATED_PRINTS - Added learnVerbose flag and logout timer cleanup. (Smartbot/Smartbot.lua)
 BLOCKER: Missing Lua interpreter; cannot execute self-tests or /sb learn health to finalize.
 BLOCKER: Apt repository 403 prevents installing Lua interpreter; tests and health check remain unrun.
+CI_INSTALLED: .github/workflows/lua-tests.yml - Added CI workflow and local spec runner (scripts/run_specs.lua, README.md).

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# WoWAddons
+
+This repository contains World of Warcraft addons including Smartbot.
+
+## Tests
+
+Run all Lua specs locally (requires a local Lua interpreter):
+
+```
+lua scripts/run_specs.lua
+```
+
+GitHub Actions runs the Lua specs automatically on every push and pull request.

--- a/scripts/run_specs.lua
+++ b/scripts/run_specs.lua
@@ -1,0 +1,30 @@
+-- Portable runner for local use (no external libs).
+-- Runs every *_spec.lua tracked by git, in sorted order.
+local function read_specs()
+  local f = io.popen("git ls-files \"*_spec.lua\"")
+  if not f then return {} end
+  local t = {}
+  for line in f:lines() do t[#t+1] = line end
+  f:close()
+  table.sort(t)
+  return t
+end
+
+local failures = 0
+for _, path in ipairs(read_specs()) do
+  io.stdout:write("[RUN] "..path.."\n")
+  local chunk, loadErr = loadfile(path)
+  if not chunk then
+    io.stderr:write("[FAIL] "..path..": "..tostring(loadErr).."\n")
+    failures = failures + 1
+  else
+    local ok, runErr = pcall(chunk)
+    if not ok then
+      io.stderr:write("[FAIL] "..path..": "..tostring(runErr).."\n")
+      failures = failures + 1
+    else
+      io.stdout:write("[ OK] "..path.."\n")
+    end
+  end
+end
+if failures > 0 then os.exit(1) end


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run Lua specs on push/PR
- add portable `scripts/run_specs.lua`
- document test instructions in README
- track CI status in `.smartbot/STATUS.json`

## Testing
- `lua scripts/run_specs.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b92ff6526c8328ac069ad19a10093d