### PR TITLE
Add performance guards and logging

### DIFF
--- a/AddOns/SmartWeaver/Core.lua
+++ b/AddOns/SmartWeaver/Core.lua
@@ -27,17 +27,22 @@ end
 
 function Core:SpecRole()
     local spec = GetSpecialization()
-    if not spec then return end
+    if not spec then
+        U.log("Spec not ready, retrying")
+        C_Timer.After(2, function() Core:SpecRole() end)
+        return
+    end
     local specID = GetSpecializationInfo(spec)
     local role = GetSpecializationRole(spec)
     local name, realm = UnitName("player"), GetRealmName()
     state.specID = specID
     state.role = role
     state.charKey = name.."-"..realm..":"..specID
+    U.log("SpecRole detected %s %s", tostring(specID), tostring(role))
 end
 
 function Core:SlashCmd()
-    print("SmartWeaver status: spec="..(state.specID or "?").." role="..(state.role or "?"))
+    print("SmartWeaver status: spec="..(state.specID or "?").." role="..(state.role or "?"))")
     if SW.UI and SW.UI.Open then SW.UI:Open() end
 end
 

--- a/AddOns/SmartWeaver/Equip.lua
+++ b/AddOns/SmartWeaver/Equip.lua
@@ -1,12 +1,16 @@
 local ADDON_NAME, SW = ...
 SW.Equip = {}
 local E = SW.Equip
+local U = SW.Util
 
 function E:Equip(info)
-    if not info or InCombatLockdown() then return end
+    if not info or InCombatLockdown() then
+        U.log("Equip skipped")
+        return end
     if info.bag and info.index then
         C_Container.PickupContainerItem(info.bag, info.index)
         EquipCursorItem(info.slot)
+        U.log("Equipped item from bag %d index %d to slot %d", info.bag, info.index, info.slot)
     end
 end
 

--- a/AddOns/SmartWeaver/Events.lua
+++ b/AddOns/SmartWeaver/Events.lua
@@ -18,6 +18,7 @@ function E:Init()
     f:RegisterEvent("PLAYER_REGEN_DISABLED")
     f:RegisterEvent("PLAYER_REGEN_ENABLED")
     f:RegisterEvent("COMBAT_LOG_EVENT_UNFILTERED")
+    f:RegisterEvent("GET_ITEM_INFO_RECEIVED")
 end
 
 function E:PLAYER_SPECIALIZATION_CHANGED(unit)
@@ -32,11 +33,16 @@ function E:PLAYER_EQUIPMENT_CHANGED()
     SW.ItemStats:Invalidate()
 end
 
+function E:GET_ITEM_INFO_RECEIVED()
+    SW.ItemStats:Invalidate()
+end
+
 function E:PLAYER_REGEN_DISABLED()
     combat.active=true
     combat.start=GetTime()
     combat.damage=0
     combat.healing=0
+    U.log("Combat started")
 end
 
 function E:PLAYER_REGEN_ENABLED()
@@ -46,6 +52,7 @@ function E:PLAYER_REGEN_ENABLED()
             local dps = combat.damage/dur
             local hps = combat.healing/dur
             SW.Learner:RecordEncounter(dps,hps)
+            U.log("Combat ended: dps=%.1f hps=%.1f", dps, hps)
         end
     end
     combat.active=false

--- a/AddOns/SmartWeaver/ItemStats.lua
+++ b/AddOns/SmartWeaver/ItemStats.lua
@@ -23,6 +23,12 @@ local statOrder = {
 function IS:Features(link)
     if not link then return end
     if cache[link] then return cache[link] end
+    if not GetItemInfo(link) then
+        local id = tonumber(link:match("item:(%d+)") or "")
+        if id then C_Item.RequestLoadItemDataByID(id) end
+        U.log("Item not cached, requesting %s", link)
+        return
+    end
     local stats = C_Item.GetItemStats(link) or {}
     local f = {}
     local primary = stats[C.PRIMARY_STATS.STRENGTH] or stats[C.PRIMARY_STATS.AGILITY] or stats[C.PRIMARY_STATS.INTELLECT] or 0

--- a/AddOns/SmartWeaver/Learner.lua
+++ b/AddOns/SmartWeaver/Learner.lua
@@ -10,6 +10,7 @@ end
 
 local function initModel()
     local key = SW.state.charKey
+    if not key then return end
     local m = SW.db.models[key]
     if not m then
         local n=10
@@ -38,24 +39,28 @@ end
 
 function L:RecordEncounter(dps,hps)
     local m = initModel()
+    if not m then return end
     local x = equippedFeatures()
     if not x then return end
     local y = (SW.state.role==C.ROLES.HEALER) and hps or dps
     if not y or y<=0 then return end
-    m.A = U.matAdd(U.scalarMulMat(C.FORGET, m.A), U.outer(x))
-    m.b = U.vecAdd(U.scalarMulVec(C.FORGET, m.b), U.scalarMulVec(y, x))
-    m.w = U.matVecMul(U.invert(m.A), m.b)
-    m.samples = m.samples + 1
-    local hist = SW.db.history
-    hist[#hist+1] = {dps=dps,hps=hps,ts=time()}
-    if #hist>C.HISTORY_MAX then table.remove(hist,1) end
+    U.defer(function()
+        m.A = U.matAdd(U.scalarMulMat(C.FORGET, m.A), U.outer(x))
+        m.b = U.vecAdd(U.scalarMulVec(C.FORGET, m.b), U.scalarMulVec(y, x))
+        m.w = U.matVecMul(U.invert(m.A), m.b)
+        m.samples = m.samples + 1
+        local hist = SW.db.history
+        hist[#hist+1] = {dps=dps,hps=hps,ts=time()}
+        if #hist>C.HISTORY_MAX then table.remove(hist,1) end
+        U.log("Learner updated: %d samples", m.samples)
+    end)
 end
 
 local priors = {1,0.1,0.5,0.5,0.5,0.5,0.05,0.01,0.01,0.1}
 
 function L:GetWeights()
     local m = initModel()
-    if m.samples < C.COLD_START_SAMPLES then
+    if not m or m.samples < C.COLD_START_SAMPLES then
         return priors, true
     end
     return m.w

--- a/AddOns/SmartWeaver/Queue.lua
+++ b/AddOns/SmartWeaver/Queue.lua
@@ -1,16 +1,22 @@
 local ADDON_NAME, SW = ...
 SW.Queue = {items={}}
 local Q = SW.Queue
+local U = SW.Util
 
 function Q:Add(slot, bag, index)
     self.items[#self.items+1] = {slot=slot,bag=bag,index=index}
+    U.log("Queued item slot=%d bag=%s index=%s", slot, tostring(bag), tostring(index))
     self:Process()
 end
 
 function Q:Process()
-    if InCombatLockdown() or UnitCastingInfo("player") or UnitChannelInfo("player") then return end
     if #self.items==0 then return end
+    if InCombatLockdown() or UnitCastingInfo("player") or UnitChannelInfo("player") then
+        U.log("Queue blocked: in combat or casting")
+        return
+    end
     local item = table.remove(self.items,1)
+    U.log("Processing equip for slot %d", item.slot)
     SW.Equip:Equip(item)
     if #self.items>0 then
         C_Timer.After(0.5,function() Q:Process() end)

--- a/AddOns/SmartWeaver/Util.lua
+++ b/AddOns/SmartWeaver/Util.lua
@@ -8,6 +8,19 @@ function U.log(msg, ...)
     end
 end
 
+function U.warn(msg, ...)
+    print("["..ADDON_NAME.."] "..string.format(msg, ...))
+end
+
+function U.defer(func, delay)
+    delay = delay or 0
+    if InCombatLockdown() then
+        C_Timer.After(1, function() U.defer(func, delay) end)
+    else
+        C_Timer.After(delay, func)
+    end
+end
+
 function U.identity(n)
     local I = {}
     for i=1,n do

--- a/codex_plan.json
+++ b/codex_plan.json
@@ -28,26 +28,27 @@
     "tooltip_overlay",
     "settings_ui",
     "dev_harness",
-    "docs_and_license"
+    "docs_and_license",
+    "perf_guards_and_logging"
   ],
   "files_checksum": {
     "AddOns/SmartWeaver/Constants.lua": "f4d4c7251c020009bd8cdd6208bc18b477ac8104de39a1328ef49de405f67947",
-    "AddOns/SmartWeaver/Core.lua": "2298bcccdfe905f6258529723fdabbf281bcfa7b190da6eb330fcbbd0d15a6df",
+    "AddOns/SmartWeaver/Core.lua": "65048dcdda236a3dbfdebd9cf19eee136db023d323bada5e976dc15d99ed7b7e",
     "AddOns/SmartWeaver/DevHarness/README.md": "fe0e7bd8983b8900a1911c50e9175824deb086cba9c20e3322adb69afe9d2f2d",
     "AddOns/SmartWeaver/DevHarness/test_learner.lua": "42bc5cdff615d528a5b1b965d4be68382cbf416e8e40217c01ced84e60e1492a",
     "AddOns/SmartWeaver/DevHarness/test_scoring.lua": "92f01ad746f09c682a8decabc2b1bd716f37de2a00a240f8259b4f353fb5c2b4",
     "AddOns/SmartWeaver/DevHarness/wow_stubs.lua": "ba4a8a261ee8445b020781819fd4fbb093e7128fdd9a630eec4804da29ea3485",
-    "AddOns/SmartWeaver/Equip.lua": "757599e173a4c51fbe7e15a50635f0cde0cdee86641afc388c9e799c9618436f",
-    "AddOns/SmartWeaver/Events.lua": "532c7a3219d90496312ab6b6cd9a9abddf4dbaa584ed5ceed22b6b2ff733c963",
-    "AddOns/SmartWeaver/ItemStats.lua": "10df27f39a1c05136342f5d797d7c3430f44c4ec05016433f42b74284b4a31b5",
+    "AddOns/SmartWeaver/Equip.lua": "ffbb08a7accf5dd6da1dceec8000975b2e4d6196e0ee63ae8c28f967c58f87eb",
+    "AddOns/SmartWeaver/Events.lua": "71fb7a64045b0900ed2924ebefd0e32239f8ef7a3b038c1bf193394dbcbcfee1",
+    "AddOns/SmartWeaver/ItemStats.lua": "db9d58bbf7d7e4be557e844113d070aa9e6cfc3e8988a2308f9f3a51f62b2c18",
     "AddOns/SmartWeaver/LICENSE.txt": "d831db55645e47ca8e491c5a0e37f1ee744d7b10bf5aa8d50146c795ac0176c0",
-    "AddOns/SmartWeaver/Learner.lua": "937c34e650fc25f12b87a6b4bd7103086889eebd9c866e40aeb34b641eabb16e",
-    "AddOns/SmartWeaver/Queue.lua": "1ebd55bbdddb05542803f3cab8c2d891f8842fd2369e71721496a202b2dae6eb",
+    "AddOns/SmartWeaver/Learner.lua": "8c9291f1fb31a9c33cadf9fba7e019eea679b17da6fa88035acec9e3e3cdfc27",
+    "AddOns/SmartWeaver/Queue.lua": "c0db90c0fe99787a8c6a2b82569c553a4af12cd5773af42f32aa581c1d4ea204",
     "AddOns/SmartWeaver/README.md": "7bba8d02d95c59b21e5743633c09f8c1d07529aeaea7cc4807cc5e363fb8aa94",
     "AddOns/SmartWeaver/Scoring.lua": "4a6833abef64269e3d7362a617543220f580c49bf52f7c13cfc077bb9b6fdd11",
     "AddOns/SmartWeaver/SmartWeaver.toc": "f93406490fef7ee4ef97d78863dadd9e1f1bdb24a031244bfa57c88bf95a4cd4",
     "AddOns/SmartWeaver/Tooltip.lua": "538506ee9a736ae11164dbbc96c84406db9e5d43b0c0644bf77def39007829e8",
     "AddOns/SmartWeaver/UI.lua": "2c50263102e273193c67dc394e81013275de36088c9fcc590609d6a5562fa581",
-    "AddOns/SmartWeaver/Util.lua": "b10126985f5f523d683985f37899058294f440d2cc628ffed4ead74fdfb7c530"
+    "AddOns/SmartWeaver/Util.lua": "0683c5cdd6f974fa19362afb33d3cd9f1f08ccd989f8cfcd53449c6eb81464dc"
   }
 }


### PR DESCRIPTION
## Summary
- add deferred execution helper and warn logging
- guard learner updates and item stat retrieval
- extend event handling, equip queue, and spec detection with logs and combat checks

## Testing
- `lua AddOns/SmartWeaver/DevHarness/test_learner.lua` *(fails: command not found)*
- `apt-get update` *(403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b95371aa80832880474c5b27c4865a