### PR TITLE
Implement combat log tracking in Smartbot

### DIFF
--- a/Smartbot/Smartbot.lua
+++ b/Smartbot/Smartbot.lua
@@ -13,8 +13,10 @@ local GetCurrentModel
 SmartbotDB = SmartbotDB or {}
 
 local currentSegment
+local playerGUID
 
 function Smartbot:OnCombatStart()
+    playerGUID = UnitGUID and UnitGUID("player") or nil
     local now = GetTime and GetTime() or 0
     currentSegment = Segment:New(now)
     currentSegment.features = Features.BuildEquippedVector()
@@ -27,14 +29,43 @@ function Smartbot:OnCombatEnd()
     end
 end
 
+function Smartbot:OnCombatLog()
+    if not currentSegment then return end
+    local timestamp, subevent, _, sourceGUID, _, _, _, destGUID, _, _, _, arg12, _, _, arg15 = CombatLogGetCurrentEventInfo()
+    if not sourceGUID then return end
+    local petGUID = UnitGUID and UnitGUID("pet") or nil
+    local vehicleGUID = UnitGUID and UnitGUID("vehicle") or nil
+    if sourceGUID ~= playerGUID and sourceGUID ~= petGUID and sourceGUID ~= vehicleGUID then
+        return
+    end
+    local amount
+    local isHeal = false
+    if subevent == "SWING_DAMAGE" then
+        amount = arg12
+    elseif subevent == "RANGE_DAMAGE" or subevent == "SPELL_DAMAGE" or subevent == "SPELL_PERIODIC_DAMAGE" then
+        amount = arg15
+    elseif subevent == "SPELL_HEAL" or subevent == "SPELL_PERIODIC_HEAL" then
+        amount = arg15
+        isHeal = true
+    else
+        return
+    end
+    if amount and amount > 0 then
+        currentSegment:AddEvent(timestamp, destGUID, amount, isHeal)
+    end
+end
+
 local frame = CreateFrame("Frame")
 frame:RegisterEvent("PLAYER_REGEN_DISABLED")
 frame:RegisterEvent("PLAYER_REGEN_ENABLED")
+frame:RegisterEvent("COMBAT_LOG_EVENT_UNFILTERED")
 frame:SetScript("OnEvent", function(_, event)
     if event == "PLAYER_REGEN_DISABLED" then
         Smartbot:OnCombatStart()
     elseif event == "PLAYER_REGEN_ENABLED" then
         Smartbot:OnCombatEnd()
+    elseif event == "COMBAT_LOG_EVENT_UNFILTERED" then
+        Smartbot:OnCombatLog()
     end
 end)
 

--- a/codex_plan.json
+++ b/codex_plan.json
@@ -17,13 +17,14 @@
   ],
   "completed": [
     "repair_segment_class_and_forward_decls",
-    "equip_snapshot_features"
+    "equip_snapshot_features",
+    "combat_logger_dps_hps"
   ],
   "files_checksum": {
     "Smartbot/Segment.lua": "e1210747e397ee040dd0501c54824b8f7a7ecc1d5dab42e80ffa3e47d7e0db22",
     "Smartbot/Features.lua": "8bdc5a332a263404c931b9e143187a00dc3a7c2ddd0af0098981ca0e16c6c74f",
     "Smartbot/Model.lua": "a0800e7bce6bf812a1de6efba1b93bacc1254f53a8b5e2bc98a2b95dd245ec04",
-    "Smartbot/Smartbot.lua": "db9eed52f4bdcab3c6501a88d5a3b2710d7816a237cc4190091eb26f678d6a75",
+    "Smartbot/Smartbot.lua": "655f19eb333965b7a301bda9c148320fac87b5499dd66d6003c64879d263fa9f",
     "Smartbot/Smartbot.toc": "9a361980239a62eea5b5ec67ae9faa52d2b0b3b1171458be7a94dd7e05abc15e",
     "tests/segment_spec.lua": "83c225ba83d1cc750c59fb867b781fb471f4195421977111483cef69b74193ec"
   }


### PR DESCRIPTION
## Summary
- Start combat segments with a gear snapshot and player GUID
- Track damage and healing events via COMBAT_LOG_EVENT_UNFILTERED
- Compute DPS/HPS per segment for later learning

## Testing
- `lua tests/segment_spec.lua` *(fails: command not found)*
- `apt-get install -y lua5.4` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68ba9bc6ccc883288db840d4f5fdd2c7