### PR TITLE
feat: blend learners and persist models

### DIFF
--- a/codex_plan.json
+++ b/codex_plan.json
@@ -21,13 +21,14 @@
     "combat_logger_dps_hps",
     "context_bucket_and_outlier_handler",
     "rls_model_core",
-    "delta_pairwise_model"
+    "delta_pairwise_model",
+    "blended_weights_and_persistence"
   ],
   "files_checksum": {
     "Smartbot/Segment.lua": "7a98d21723a3ff31be5c7c40f049767d85cc28ded5ff103c563bc2b56f9cd37b",
     "Smartbot/Features.lua": "8bdc5a332a263404c931b9e143187a00dc3a7c2ddd0af0098981ca0e16c6c74f",
-    "Smartbot/Model.lua": "d104c0633424c384b80b44a1dfaf19d2c8cbbfcbdd8f2aa904fa54ffccd6a379",
-    "Smartbot/Smartbot.lua": "34643b2e0ebba6cf559cf1caabef20c02c33bd05eff7f8b155804de5fc48debc",
+    "Smartbot/Model.lua": "f4f528b456bf7b338921c136413ae44a98e63fda2a4c131bd56b9bd783a5d7a2",
+    "Smartbot/Smartbot.lua": "c5e6f1e5d64f4019d3d9bb9d79134b1741ba4d84e8399258779c36e8118db5f6",
     "Smartbot/Smartbot.toc": "9a361980239a62eea5b5ec67ae9faa52d2b0b3b1171458be7a94dd7e05abc15e",
     "tests/segment_spec.lua": "83c225ba83d1cc750c59fb867b781fb471f4195421977111483cef69b74193ec"
   }


### PR DESCRIPTION
## Summary
- add blended model wrapper combining RLS and delta learners with reliability-based weight
- persist models per character/spec/role/context and record segment history
- update combat end handling to feed delta updates and save model state

## Testing
- `lua tests/segment_spec.lua` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bab4c77b9c8328a39f17c3c1a67675