### PR TITLE
feat: add safe auto-equipping queue

### DIFF
--- a/codex_plan.json
+++ b/codex_plan.json
@@ -23,13 +23,14 @@
     "rls_model_core",
     "delta_pairwise_model",
     "blended_weights_and_persistence",
-    "tooltip_overlay"
+    "tooltip_overlay",
+    "retail_safe_equip_queue"
   ],
   "files_checksum": {
     "Smartbot/Segment.lua": "7a98d21723a3ff31be5c7c40f049767d85cc28ded5ff103c563bc2b56f9cd37b",
     "Smartbot/Features.lua": "8bdc5a332a263404c931b9e143187a00dc3a7c2ddd0af0098981ca0e16c6c74f",
     "Smartbot/Model.lua": "f4f528b456bf7b338921c136413ae44a98e63fda2a4c131bd56b9bd783a5d7a2",
-    "Smartbot/Smartbot.lua": "79e72593c765456b282b21723fde15580e44d44f7177970eaa36207d7bf00a8a",
+    "Smartbot/Smartbot.lua": "68d82b7e403a06cfa451f43a41f19e79eaf65613028bca4aac3c298d6727a3fd",
     "Smartbot/Smartbot.toc": "9a361980239a62eea5b5ec67ae9faa52d2b0b3b1171458be7a94dd7e05abc15e",
     "tests/segment_spec.lua": "83c225ba83d1cc750c59fb867b781fb471f4195421977111483cef69b74193ec"
   }


### PR DESCRIPTION
## Summary
- add heuristic fallback scoring when model undertrained
- scan bag items after combat and queue upgrades
- equip queued items out of combat with GCD and cast safety

## Testing
- `lua tests/segment_spec.lua` *(fails: command not found)*
- `rg " \\.. " Smartbot/Smartbot.lua Smartbot/Segment.lua Smartbot/Model.lua Smartbot/Features.lua Smartbot/Smartbot.toc`


------
https://chatgpt.com/codex/tasks/task_e_68babe3d5b5083288cbe65cf0032746a