### PR TITLE
Add upgrade evaluation and equip queue with slot coupling

### DIFF
--- a/Smartbot/Core.lua
+++ b/Smartbot/Core.lua
@@ -39,9 +39,13 @@ local function processQueue()
     if entry then
         local item, slot = entry.item, entry.slot
         if item then
-            local ok, err = pcall(EquipItemByName, item, slot)
-            if not ok and Smartbot.Logger then
-                Smartbot.Logger:Log("WARN", "Equip failed", item, err)
+            if Smartbot.Equip and Smartbot.Equip.Validate and not Smartbot.Equip:Validate(item, slot) then
+                -- skip invalid or outdated entry
+            else
+                local ok, err = pcall(EquipItemByName, item, slot)
+                if not ok and Smartbot.Logger then
+                    Smartbot.Logger:Log("WARN", "Equip failed", item, err)
+                end
             end
         end
     end

--- a/Smartbot/Equip.lua
+++ b/Smartbot/Equip.lua
@@ -1,0 +1,198 @@
+local addonName, Smartbot = ...
+Smartbot.Equip = Smartbot.Equip or {}
+local Equip = Smartbot.Equip
+
+local API = Smartbot.API
+
+local CreateFrame = API:Resolve('CreateFrame') or CreateFrame
+local InCombatLockdown = API:Resolve('InCombatLockdown') or InCombatLockdown
+local GetInventoryItemLink = API:Resolve('GetInventoryItemLink') or GetInventoryItemLink
+local GetInventorySlotInfo = API:Resolve('GetInventorySlotInfo') or GetInventorySlotInfo
+local GetItemInfoInstant = API:Resolve('GetItemInfoInstant') or (C_Item and C_Item.GetItemInfoInstant)
+local GetTime = API:Resolve('GetTime') or GetTime
+local UnitAffectingCombat = API:Resolve('UnitAffectingCombat') or UnitAffectingCombat
+
+local C_Container = API:Resolve('C_Container') or C_Container
+local GetContainerNumSlots = (C_Container and C_Container.GetContainerNumSlots) or API:Resolve('GetContainerNumSlots')
+local GetContainerItemLink = (C_Container and C_Container.GetContainerItemLink) or API:Resolve('GetContainerItemLink')
+
+local ItemScore = Smartbot.ItemScore
+
+local slots = {
+    HEAD = {GetInventorySlotInfo('HeadSlot')},
+    NECK = {GetInventorySlotInfo('NeckSlot')},
+    SHOULDER = {GetInventorySlotInfo('ShoulderSlot')},
+    CHEST = {GetInventorySlotInfo('ChestSlot')},
+    WAIST = {GetInventorySlotInfo('WaistSlot')},
+    LEGS = {GetInventorySlotInfo('LegsSlot')},
+    FEET = {GetInventorySlotInfo('FeetSlot')},
+    WRIST = {GetInventorySlotInfo('WristSlot')},
+    HAND = {GetInventorySlotInfo('HandsSlot')},
+    FINGER = {GetInventorySlotInfo('Finger0Slot'), GetInventorySlotInfo('Finger1Slot')},
+    TRINKET = {GetInventorySlotInfo('Trinket0Slot'), GetInventorySlotInfo('Trinket1Slot')},
+    CLOAK = {GetInventorySlotInfo('BackSlot')},
+    MAINHAND = {GetInventorySlotInfo('MainHandSlot')},
+    OFFHAND = {GetInventorySlotInfo('SecondaryHandSlot')},
+}
+
+local invTypeToSlots = {
+    INVTYPE_HEAD = slots.HEAD,
+    INVTYPE_NECK = slots.NECK,
+    INVTYPE_SHOULDER = slots.SHOULDER,
+    INVTYPE_CHEST = slots.CHEST,
+    INVTYPE_WAIST = slots.WAIST,
+    INVTYPE_LEGS = slots.LEGS,
+    INVTYPE_FEET = slots.FEET,
+    INVTYPE_WRIST = slots.WRIST,
+    INVTYPE_HAND = slots.HAND,
+    INVTYPE_FINGER = slots.FINGER,
+    INVTYPE_TRINKET = slots.TRINKET,
+    INVTYPE_CLOAK = slots.CLOAK,
+    INVTYPE_WEAPON = {slots.MAINHAND[1], slots.OFFHAND[1]},
+    INVTYPE_WEAPONMAINHAND = slots.MAINHAND,
+    INVTYPE_WEAPONOFFHAND = slots.OFFHAND,
+    INVTYPE_2HWEAPON = {slots.MAINHAND[1], slots.OFFHAND[1]},
+    INVTYPE_SHIELD = slots.OFFHAND,
+    INVTYPE_HOLDABLE = slots.OFFHAND,
+    INVTYPE_RANGED = slots.MAINHAND,
+    INVTYPE_RANGEDRIGHT = slots.MAINHAND,
+    INVTYPE_THROWN = slots.MAINHAND,
+}
+
+local lastEquipTime = {}
+
+local function getEquippedScore(slot)
+    local link = GetInventoryItemLink('player', slot)
+    if link and ItemScore:IsAllowed(link) then
+        return ItemScore:GetScore(link), link
+    end
+    return 0, link
+end
+
+function Equip:Validate(itemLink, slot)
+    local _, _, _, equipLoc = GetItemInfoInstant(itemLink)
+    local slotsGroup = invTypeToSlots[equipLoc]
+    if not slotsGroup then return false end
+    local delta
+    local minDelta = Smartbot.db.profile.minDelta or 0
+    if equipLoc == 'INVTYPE_FINGER' or equipLoc == 'INVTYPE_TRINKET' then
+        local newScore = ItemScore:GetScore(itemLink)
+        local currentScore = getEquippedScore(slot)
+        delta = newScore - currentScore
+    elseif equipLoc == 'INVTYPE_2HWEAPON' then
+        local mh, oh = slots.MAINHAND[1], slots.OFFHAND[1]
+        local current = select(1, getEquippedScore(mh)) + select(1, getEquippedScore(oh))
+        delta = ItemScore:GetScore(itemLink) - current
+    else
+        local currentScore = getEquippedScore(slot)
+        delta = ItemScore:GetScore(itemLink) - currentScore
+    end
+    return delta and delta >= minDelta
+end
+
+local function shouldEquip(slot)
+    local now = GetTime()
+    if lastEquipTime[slot] and now - lastEquipTime[slot] < 2 then
+        return false
+    end
+    lastEquipTime[slot] = now
+    return true
+end
+
+local function queueUpgrade(itemLink, slot)
+    if not itemLink or not slot then return end
+    if not Equip:Validate(itemLink, slot) then return end
+    if InCombatLockdown() or UnitAffectingCombat('player') then return end
+    if not shouldEquip(slot) then return end
+    Smartbot:QueueEquip(itemLink, slot)
+end
+
+local function evaluateBasic(itemLink, slotsGroup)
+    local minDelta = Smartbot.db.profile.minDelta or 0
+    local newScore = ItemScore:GetScore(itemLink)
+    local bestSlot, bestDelta
+    for _, slot in ipairs(slotsGroup) do
+        local currentScore = getEquippedScore(slot)
+        local delta = newScore - currentScore
+        if delta > minDelta and (not bestDelta or delta > bestDelta) then
+            bestDelta = delta
+            bestSlot = slot
+        end
+    end
+    if bestSlot then
+        queueUpgrade(itemLink, bestSlot)
+    end
+end
+
+local function evaluateTwoHand(itemLink)
+    local mh, oh = slots.MAINHAND[1], slots.OFFHAND[1]
+    local current = select(1, getEquippedScore(mh)) + select(1, getEquippedScore(oh))
+    local newScore = ItemScore:GetScore(itemLink)
+    if newScore - current >= (Smartbot.db.profile.minDelta or 0) then
+        queueUpgrade(itemLink, mh)
+    end
+end
+
+local function evaluateOneHandCandidates(candidates)
+    local mhSlot, ohSlot = slots.MAINHAND[1], slots.OFFHAND[1]
+    local current = select(1, getEquippedScore(mhSlot)) + select(1, getEquippedScore(ohSlot))
+    table.sort(candidates, function(a, b) return a.score > b.score end)
+    if #candidates >= 2 then
+        local newScore = candidates[1].score + candidates[2].score
+        if newScore - current >= (Smartbot.db.profile.minDelta or 0) then
+            queueUpgrade(candidates[1].link, mhSlot)
+            queueUpgrade(candidates[2].link, ohSlot)
+            return
+        end
+    end
+    -- evaluate individually against slots
+    for _, cand in ipairs(candidates) do
+        evaluateBasic(cand.link, {mhSlot, ohSlot})
+    end
+end
+
+function Equip:Scan()
+    if not Smartbot.db or not Smartbot.db.profile then return end
+    local oneHand = {}
+    for bag = 0, 4 do
+        local slotsCount = GetContainerNumSlots(bag) or 0
+        for slot = 1, slotsCount do
+            local link = GetContainerItemLink(bag, slot)
+            if link and ItemScore:IsAllowed(link) then
+                local _, _, _, equipLoc = GetItemInfoInstant(link)
+                local group = invTypeToSlots[equipLoc]
+                if group then
+                    if equipLoc == 'INVTYPE_2HWEAPON' then
+                        evaluateTwoHand(link)
+                    elseif equipLoc == 'INVTYPE_WEAPON' then
+                        table.insert(oneHand, {link = link, score = ItemScore:GetScore(link)})
+                    elseif equipLoc == 'INVTYPE_WEAPONMAINHAND' or equipLoc == 'INVTYPE_WEAPONOFFHAND' or equipLoc == 'INVTYPE_SHIELD' or equipLoc == 'INVTYPE_HOLDABLE' then
+                        evaluateBasic(link, group)
+                    else
+                        evaluateBasic(link, group)
+                    end
+                end
+            end
+        end
+    end
+    if GetInventoryItemLink('player', slots.OFFHAND[1]) == nil and GetInventoryItemLink('player', slots.MAINHAND[1]) and select(4, GetItemInfoInstant(GetInventoryItemLink('player', slots.MAINHAND[1]))) == 'INVTYPE_2HWEAPON' then
+        if #oneHand >= 2 then
+            evaluateOneHandCandidates(oneHand)
+        end
+    else
+        if #oneHand > 0 then
+            evaluateOneHandCandidates(oneHand)
+        end
+    end
+end
+
+local frame = CreateFrame('Frame')
+frame:RegisterEvent('PLAYER_LOGIN')
+frame:RegisterEvent('BAG_UPDATE_DELAYED')
+frame:RegisterEvent('PLAYER_EQUIPMENT_CHANGED')
+frame:SetScript('OnEvent', function()
+    Equip:Scan()
+end)
+
+return Equip
+

--- a/Smartbot/HEALTH.md
+++ b/Smartbot/HEALTH.md
@@ -1,8 +1,8 @@
 # Smartbot Health
 
 ## Status
-- RGAR map generated from reference addons
-- API adapter resolving Retail functions
+- Core, logger, RGAR map, class/spec rules and item scoring ready
+- Equip pipeline with OOC queue, min-delta damping, and slot coupling active
 
 ## Next Steps
-- Implement ClassSpecRules and ItemScore scaffolding
+- Integrate tooltip score deltas via RGAR runtime adapter

--- a/Smartbot/Smartbot.toc
+++ b/Smartbot/Smartbot.toc
@@ -10,3 +10,4 @@ Core.lua
 Logger.lua
 ClassSpecRules.lua
 ItemScore.lua
+Equip.lua

--- a/smartbot.plan.json
+++ b/smartbot.plan.json
@@ -19,7 +19,7 @@
     {
       "id": 4,
       "name": "Equip pipeline with OOC queue, min-delta damping, and slot coupling",
-      "status": "pending"
+      "status": "complete"
     },
     {
       "id": 5,
@@ -53,8 +53,8 @@
     }
   ],
   "file_checksums": {
-    "Smartbot/Smartbot.toc": "9cba5c67b54dd14e5ab7479c50a1927f60467d5ad800ab2a545cca800786da92",
-    "Smartbot/Core.lua": "40f4ba9eabb166056ba31b8e9b14342741f85768f4d955dabaec343feac4c255",
+    "Smartbot/Smartbot.toc": "b160ddb640211b4e61b8f18bf62079877487786d13cb55bbf9b4d365dcd9b3c5",
+    "Smartbot/Core.lua": "61e30e7b2ec9d32ecb88d1c92d3c4d11e1551069520f7bee290966b68d11ea42",
     "Smartbot/Logger.lua": "fab85d15b7129059aeaf30a0017ef636ebe814016c9587f61564f5d24ed74c14",
     "README.md": "327da4aa6f3e745803654d0192afce85f903055259c3d61ddb12cf3d4847a72c",
     "LICENSE": "731683113662b881f8b6ad6fa743c5d8bd9eb488ec2011104e384665cd1d6443",
@@ -63,10 +63,11 @@
     "Smartbot/APIMap.lua": "b28b96638707be52d0115bc5166b95a1a15c63febcee48bb9d92bc9637760ce4",
     "Smartbot/.cache/retail_api_map.json": "ba32b2adf30b3f7245ac9be836ca983a1192972208a194ce4a275bde680fc6c2",
     "Smartbot/tools/build_rgar.py": "4b0f48638e5ccf858c606298ef743995acadf1c6419732861735ae2c0971647c",
-    "Smartbot/HEALTH.md": "98050d0ec0d29c00fc0b74f09ba370235a0240a88ade2323c9b29e5dc12cbf3d",
+    "Smartbot/HEALTH.md": "3b8a574afe6d5c97a4e6ed6b309fe8e422d810efe1ee772411099bd3d248d46e",
     "Smartbot/ClassSpecRules.lua": "4e0f7a81b8169776d3111f151fee3568c5bba7eb7d49c43faa896fd6ec8974aa",
     "Smartbot/ItemScore.lua": "6553a3548a8232f1f598b664bd17b74b792d9af0dd2ad109cf202ac9f3600072",
-    "Smartbot/tools/extract_rules.py": "04dea0aee02c0958ce9489d0c2aab3ad1f9e694d0cadee8f08e24e550e485776"
+    "Smartbot/tools/extract_rules.py": "04dea0aee02c0958ce9489d0c2aab3ad1f9e694d0cadee8f08e24e550e485776",
+    "Smartbot/Equip.lua": "465f7804478461d457a4e14e733f25b972d49eb3ee705579d874afb0500723b9"
   },
-  "next_run_focus": "Equip pipeline with OOC queue, min-delta damping, and slot coupling"
+  "next_run_focus": "Tooltip integration via RGAR runtime adapter"
 }


### PR DESCRIPTION
## Summary
- Implement equipment scanning and upgrade scoring with min-delta and slot coupling
- Add out-of-combat equip queue validation to prevent combat actions
- Update health report and load order

## Testing
- ⚠️ `luac -p Smartbot/Equip.lua Smartbot/Core.lua` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bbb735e9e483289e60912f1c9a700f