### PR TITLE
Add tooltip integration using RGAR

### DIFF
--- a/Smartbot/Equip.lua
+++ b/Smartbot/Equip.lua
@@ -59,6 +59,8 @@ local invTypeToSlots = {
     INVTYPE_THROWN = slots.MAINHAND,
 }
 
+Equip.invTypeToSlots = invTypeToSlots
+
 local lastEquipTime = {}
 
 local function getEquippedScore(slot)
@@ -68,6 +70,8 @@ local function getEquippedScore(slot)
     end
     return 0, link
 end
+
+Equip.GetEquippedScore = getEquippedScore
 
 function Equip:Validate(itemLink, slot)
     local _, _, _, equipLoc = GetItemInfoInstant(itemLink)

--- a/Smartbot/HEALTH.md
+++ b/Smartbot/HEALTH.md
@@ -3,6 +3,7 @@
 ## Status
 - Core, logger, RGAR map, class/spec rules and item scoring ready
 - Equip pipeline with OOC queue, min-delta damping, and slot coupling active
+- Tooltip score deltas integrated via RGAR runtime adapter
 
 ## Next Steps
-- Integrate tooltip score deltas via RGAR runtime adapter
+- Settings UI and /smartbot commands

--- a/Smartbot/Smartbot.toc
+++ b/Smartbot/Smartbot.toc
@@ -11,3 +11,4 @@ Logger.lua
 ClassSpecRules.lua
 ItemScore.lua
 Equip.lua
+Tooltip.lua

--- a/Smartbot/Tooltip.lua
+++ b/Smartbot/Tooltip.lua
@@ -1,0 +1,71 @@
+local addonName, Smartbot = ...
+Smartbot.Tooltip = Smartbot.Tooltip or {}
+local Tooltip = Smartbot.Tooltip
+
+local API = Smartbot.API
+local ItemScore = Smartbot.ItemScore
+local Equip = Smartbot.Equip
+
+local AddTooltipPostCall = API:Resolve('TooltipDataProcessor.AddTooltipPostCall')
+local GetItemInfoInstant = API:Resolve('GetItemInfoInstant') or (C_Item and C_Item.GetItemInfoInstant)
+
+local function formatDelta(delta)
+    if delta > 0 then
+        return string.format("|cff00ff00+%.1f|r", delta)
+    elseif delta < 0 then
+        return string.format("|cffff0000%.1f|r", delta)
+    else
+        return string.format("%.1f", delta)
+    end
+end
+
+local function compareScore(itemLink)
+    local _, _, _, equipLoc = GetItemInfoInstant(itemLink)
+    local slots = Equip.invTypeToSlots[equipLoc]
+    if not slots then
+        return ItemScore:GetScore(itemLink), 0
+    end
+    local newScore = ItemScore:GetScore(itemLink)
+    local delta
+    if equipLoc == 'INVTYPE_FINGER' or equipLoc == 'INVTYPE_TRINKET' then
+        for _, slot in ipairs(slots) do
+            local current = Equip.GetEquippedScore(slot)
+            local d = newScore - current
+            if not delta or d > delta then
+                delta = d
+            end
+        end
+    elseif equipLoc == 'INVTYPE_2HWEAPON' then
+        local current = Equip.GetEquippedScore(slots[1]) + Equip.GetEquippedScore(slots[2])
+        delta = newScore - current
+    else
+        local current = Equip.GetEquippedScore(slots[1])
+        delta = newScore - current
+    end
+    return newScore, delta
+end
+
+local function handleTooltip(tooltip, data)
+    local itemLink
+    if type(data) == 'table' and data.hyperlink then
+        itemLink = data.hyperlink
+    else
+        _, itemLink = tooltip:GetItem()
+    end
+    if not itemLink or not ItemScore:IsAllowed(itemLink) then return end
+    local score, delta = compareScore(itemLink)
+    tooltip:AddLine(string.format('Smartbot: %.1f (%s)', score, formatDelta(delta or 0)))
+    tooltip:Show()
+end
+
+if AddTooltipPostCall and Enum and Enum.TooltipDataType and Enum.TooltipDataType.Item then
+    AddTooltipPostCall(Enum.TooltipDataType.Item, handleTooltip)
+else
+    local GameTooltip = API:Resolve('GameTooltip') or GameTooltip
+    local HasScript = API:Resolve('HasScript') or (GameTooltip and GameTooltip.HasScript)
+    if GameTooltip and GameTooltip.HookScript and HasScript and GameTooltip:HasScript('OnTooltipSetItem') then
+        GameTooltip:HookScript('OnTooltipSetItem', handleTooltip)
+    end
+end
+
+return Tooltip

--- a/smartbot.plan.json
+++ b/smartbot.plan.json
@@ -24,7 +24,7 @@
     {
       "id": 5,
       "name": "Tooltip integration via RGAR runtime adapter",
-      "status": "pending"
+      "status": "complete"
     },
     {
       "id": 6,
@@ -53,7 +53,7 @@
     }
   ],
   "file_checksums": {
-    "Smartbot/Smartbot.toc": "b160ddb640211b4e61b8f18bf62079877487786d13cb55bbf9b4d365dcd9b3c5",
+    "Smartbot/Smartbot.toc": "c82a6116b74285a8fc5778617df48fd8a543766fe6435c31245c08505e410180",
     "Smartbot/Core.lua": "61e30e7b2ec9d32ecb88d1c92d3c4d11e1551069520f7bee290966b68d11ea42",
     "Smartbot/Logger.lua": "fab85d15b7129059aeaf30a0017ef636ebe814016c9587f61564f5d24ed74c14",
     "README.md": "327da4aa6f3e745803654d0192afce85f903055259c3d61ddb12cf3d4847a72c",
@@ -63,11 +63,12 @@
     "Smartbot/APIMap.lua": "b28b96638707be52d0115bc5166b95a1a15c63febcee48bb9d92bc9637760ce4",
     "Smartbot/.cache/retail_api_map.json": "ba32b2adf30b3f7245ac9be836ca983a1192972208a194ce4a275bde680fc6c2",
     "Smartbot/tools/build_rgar.py": "4b0f48638e5ccf858c606298ef743995acadf1c6419732861735ae2c0971647c",
-    "Smartbot/HEALTH.md": "3b8a574afe6d5c97a4e6ed6b309fe8e422d810efe1ee772411099bd3d248d46e",
+    "Smartbot/HEALTH.md": "8cca6f224d70915563db67081e41ad55c555f556848e7387f993f64757e1ffdd",
     "Smartbot/ClassSpecRules.lua": "4e0f7a81b8169776d3111f151fee3568c5bba7eb7d49c43faa896fd6ec8974aa",
     "Smartbot/ItemScore.lua": "6553a3548a8232f1f598b664bd17b74b792d9af0dd2ad109cf202ac9f3600072",
     "Smartbot/tools/extract_rules.py": "04dea0aee02c0958ce9489d0c2aab3ad1f9e694d0cadee8f08e24e550e485776",
-    "Smartbot/Equip.lua": "465f7804478461d457a4e14e733f25b972d49eb3ee705579d874afb0500723b9"
+    "Smartbot/Equip.lua": "8dd66379e63e28e741a889ca742ba58931d9a0f9721b4df1068c54e5a7365ac9",
+    "Smartbot/Tooltip.lua": "33b896ed1b87aa401e15021ac25fab57e9e0e4e09649b8dbc7f02fa6189f6c81"
   },
-  "next_run_focus": "Tooltip integration via RGAR runtime adapter"
+  "next_run_focus": "Settings UI and `/smartbot` commands"
 }


### PR DESCRIPTION
## Summary
- Hook item tooltips via RGAR with fallback to GameTooltip hooks and display Smartbot score delta
- Expose inventory slot mapping and score retrieval for reuse by tooltip
- Document current status and next steps

## Testing
- `luac -p Smartbot/Tooltip.lua Smartbot/Equip.lua` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bbbcb2cb248328b02cb5e41ed470ef