### PR TITLE
Add settings panel and slash commands

### DIFF
--- a/Smartbot/Core.lua
+++ b/Smartbot/Core.lua
@@ -89,9 +89,12 @@ eventFrame:RegisterEvent("PLAYER_REGEN_ENABLED")
 
 SLASH_SMARTBOT1 = "/smartbot"
 SlashCmdList.SMARTBOT = function(msg)
+    if Smartbot.Options and Smartbot.Options:HandleSlash(msg) then
+        return
+    end
     if Smartbot.Logger then
-        Smartbot.Logger:Log("INFO", "Command:", msg or "")
+        Smartbot.Logger:Log('INFO', 'Command:', msg or '')
     else
-        print("Smartbot:", msg)
+        print('Smartbot:', msg)
     end
 end

--- a/Smartbot/HEALTH.md
+++ b/Smartbot/HEALTH.md
@@ -4,6 +4,7 @@
 - Core, logger, RGAR map, class/spec rules and item scoring ready
 - Equip pipeline with OOC queue, min-delta damping, and slot coupling active
 - Tooltip score deltas integrated via RGAR runtime adapter
+- Settings UI and /smartbot commands available
 
 ## Next Steps
-- Settings UI and /smartbot commands
+- DetailsBridge + fallback internal meter

--- a/Smartbot/Options.lua
+++ b/Smartbot/Options.lua
@@ -1,0 +1,146 @@
+local addonName, Smartbot = ...
+Smartbot.Options = Smartbot.Options or {}
+local Options = Smartbot.Options
+
+local API = Smartbot.API
+local CreateFrame = API:Resolve('CreateFrame') or CreateFrame
+local InterfaceOptions_AddCategory = API:Resolve('InterfaceOptions_AddCategory')
+local InterfaceOptionsFrame_OpenToCategory = API:Resolve('InterfaceOptionsFrame_OpenToCategory')
+local Settings_RegisterCanvasLayoutCategory = API:Resolve('Settings.RegisterCanvasLayoutCategory')
+local Settings_RegisterAddOnCategory = API:Resolve('Settings.RegisterAddOnCategory')
+local Settings_OpenToCategory = API:Resolve('Settings.OpenToCategory')
+
+local panel
+
+local function updateWeightText()
+    if not panel or not panel.weightText then return end
+    local weights = (Smartbot.db and Smartbot.db.weights) or {}
+    local parts = {}
+    for stat, v in pairs(weights) do
+        table.insert(parts, stat .. '=' .. string.format('%.2f', v))
+    end
+    panel.weightText:SetText(#parts > 0 and table.concat(parts, ', ') or 'No weights yet')
+end
+
+function Options:ResetWeights()
+    if Smartbot.db then
+        Smartbot.db.weights = {}
+        updateWeightText()
+        if Smartbot.Logger then
+            Smartbot.Logger:Log('INFO', 'Weights reset')
+        else
+            print('Smartbot: weights reset')
+        end
+    end
+end
+
+function Options:Build()
+    if panel then return panel end
+    panel = CreateFrame('Frame')
+    panel.name = addonName
+
+    if Settings_RegisterCanvasLayoutCategory and Settings_RegisterAddOnCategory then
+        local category = Settings_RegisterCanvasLayoutCategory(panel, addonName)
+        category.ID = addonName
+        Settings_RegisterAddOnCategory(category)
+        panel.categoryID = category.ID
+    elseif InterfaceOptions_AddCategory then
+        InterfaceOptions_AddCategory(panel)
+    end
+
+    local title = panel:CreateFontString(nil, 'ARTWORK', 'GameFontNormalLarge')
+    title:SetPoint('TOPLEFT', 16, -16)
+    title:SetText('Smartbot')
+
+    local auto = CreateFrame('CheckButton', nil, panel, 'InterfaceOptionsCheckButtonTemplate')
+    auto:SetPoint('TOPLEFT', title, 'BOTTOMLEFT', 0, -8)
+    auto.Text:SetText('Enable Auto Equip')
+    auto:SetChecked(Smartbot.db.profile.autoEquip)
+    auto:SetScript('OnClick', function(self)
+        Smartbot.db.profile.autoEquip = self:GetChecked()
+    end)
+
+    local minDelta = CreateFrame('Slider', addonName..'MinDelta', panel, 'OptionsSliderTemplate')
+    minDelta:SetPoint('TOPLEFT', auto, 'BOTTOMLEFT', 0, -24)
+    minDelta:SetMinMaxValues(0, 100)
+    minDelta:SetValueStep(1)
+    minDelta:SetObeyStepOnDrag(true)
+    _G[minDelta:GetName() .. 'Low']:SetText('0')
+    _G[minDelta:GetName() .. 'High']:SetText('100')
+    _G[minDelta:GetName() .. 'Text']:SetText('Min Score Delta')
+    minDelta:SetValue(Smartbot.db.profile.minDelta)
+    minDelta:SetScript('OnValueChanged', function(self, value)
+        Smartbot.db.profile.minDelta = math.floor(value + 0.5)
+    end)
+
+    local verb = CreateFrame('Slider', addonName..'Verbosity', panel, 'OptionsSliderTemplate')
+    verb:SetPoint('TOPLEFT', minDelta, 'BOTTOMLEFT', 0, -24)
+    verb:SetMinMaxValues(0, 3)
+    verb:SetValueStep(1)
+    verb:SetObeyStepOnDrag(true)
+    _G[verb:GetName() .. 'Low']:SetText('0')
+    _G[verb:GetName() .. 'High']:SetText('3')
+    _G[verb:GetName() .. 'Text']:SetText('Verbosity')
+    verb:SetValue(Smartbot.db.profile.verbosity)
+    verb:SetScript('OnValueChanged', function(self, value)
+        Smartbot.db.profile.verbosity = math.floor(value + 0.5)
+    end)
+
+    local wt = panel:CreateFontString(nil, 'ARTWORK', 'GameFontHighlight')
+    wt:SetPoint('TOPLEFT', verb, 'BOTTOMLEFT', 0, -24)
+    wt:SetPoint('RIGHT', panel, -16, 0)
+    wt:SetJustifyH('LEFT')
+    wt:SetJustifyV('TOP')
+    panel.weightText = wt
+    updateWeightText()
+
+    local reset = CreateFrame('Button', nil, panel, 'UIPanelButtonTemplate')
+    reset:SetText('Reset Weights')
+    reset:SetWidth(120)
+    reset:SetHeight(22)
+    reset:SetPoint('TOPLEFT', wt, 'BOTTOMLEFT', 0, -24)
+    reset:SetScript('OnClick', function() Options:ResetWeights() end)
+
+    return panel
+end
+
+function Options:Open()
+    Options:Build()
+    if Settings_OpenToCategory and panel.categoryID then
+        Settings_OpenToCategory(panel.categoryID)
+    elseif InterfaceOptionsFrame_OpenToCategory then
+        InterfaceOptionsFrame_OpenToCategory(panel)
+    end
+end
+
+local function trim(s)
+    return s:match('^%s*(.-)%s*$')
+end
+
+function Options:HandleSlash(msg)
+    msg = trim(msg or ''):lower()
+    if msg == '' or msg == 'options' then
+        Options:Open()
+        return true
+    elseif msg == 'auto' then
+        Smartbot.db.profile.autoEquip = not Smartbot.db.profile.autoEquip
+        local state = Smartbot.db.profile.autoEquip and 'ON' or 'OFF'
+        if Smartbot.Logger then
+            Smartbot.Logger:Log('INFO', 'AutoEquip', state)
+        else
+            print('Smartbot auto-equip', state)
+        end
+        return true
+    elseif msg == 'reset' then
+        Options:ResetWeights()
+        return true
+    end
+    return false
+end
+
+local initFrame = CreateFrame('Frame')
+initFrame:RegisterEvent('PLAYER_LOGIN')
+initFrame:SetScript('OnEvent', function()
+    Options:Build()
+end)
+

--- a/Smartbot/Smartbot.toc
+++ b/Smartbot/Smartbot.toc
@@ -12,3 +12,4 @@ ClassSpecRules.lua
 ItemScore.lua
 Equip.lua
 Tooltip.lua
+Options.lua

--- a/smartbot.plan.json
+++ b/smartbot.plan.json
@@ -29,7 +29,7 @@
     {
       "id": 6,
       "name": "Settings UI and `/smartbot` commands",
-      "status": "pending"
+      "status": "complete"
     },
     {
       "id": 7,
@@ -53,8 +53,8 @@
     }
   ],
   "file_checksums": {
-    "Smartbot/Smartbot.toc": "c82a6116b74285a8fc5778617df48fd8a543766fe6435c31245c08505e410180",
-    "Smartbot/Core.lua": "61e30e7b2ec9d32ecb88d1c92d3c4d11e1551069520f7bee290966b68d11ea42",
+    "Smartbot/Smartbot.toc": "1b94444a1a9d903c924daf85c8da9ddd314076c3a20865547c6cb049caa9ef24",
+    "Smartbot/Core.lua": "888986f2cfeb0d235a0a9b0add363670971f4091d13b90a36a1ca1391e1ff143",
     "Smartbot/Logger.lua": "fab85d15b7129059aeaf30a0017ef636ebe814016c9587f61564f5d24ed74c14",
     "README.md": "327da4aa6f3e745803654d0192afce85f903055259c3d61ddb12cf3d4847a72c",
     "LICENSE": "731683113662b881f8b6ad6fa743c5d8bd9eb488ec2011104e384665cd1d6443",
@@ -63,12 +63,13 @@
     "Smartbot/APIMap.lua": "b28b96638707be52d0115bc5166b95a1a15c63febcee48bb9d92bc9637760ce4",
     "Smartbot/.cache/retail_api_map.json": "ba32b2adf30b3f7245ac9be836ca983a1192972208a194ce4a275bde680fc6c2",
     "Smartbot/tools/build_rgar.py": "4b0f48638e5ccf858c606298ef743995acadf1c6419732861735ae2c0971647c",
-    "Smartbot/HEALTH.md": "8cca6f224d70915563db67081e41ad55c555f556848e7387f993f64757e1ffdd",
+    "Smartbot/HEALTH.md": "6564f6847883e3f87d39fa1ad8db3abf871131b25f1f7e0379da56986a755d45",
     "Smartbot/ClassSpecRules.lua": "4e0f7a81b8169776d3111f151fee3568c5bba7eb7d49c43faa896fd6ec8974aa",
     "Smartbot/ItemScore.lua": "6553a3548a8232f1f598b664bd17b74b792d9af0dd2ad109cf202ac9f3600072",
     "Smartbot/tools/extract_rules.py": "04dea0aee02c0958ce9489d0c2aab3ad1f9e694d0cadee8f08e24e550e485776",
     "Smartbot/Equip.lua": "8dd66379e63e28e741a889ca742ba58931d9a0f9721b4df1068c54e5a7365ac9",
-    "Smartbot/Tooltip.lua": "33b896ed1b87aa401e15021ac25fab57e9e0e4e09649b8dbc7f02fa6189f6c81"
+    "Smartbot/Tooltip.lua": "33b896ed1b87aa401e15021ac25fab57e9e0e4e09649b8dbc7f02fa6189f6c81",
+    "Smartbot/Options.lua": "5ca22c67f80e006ec4af1b96b0065662a2b9b31fe7c1c9ed3a2e73abc3f9e9cf"
   },
-  "next_run_focus": "Settings UI and `/smartbot` commands"
+  "next_run_focus": "DetailsBridge + fallback internal meter"
 }


### PR DESCRIPTION
## Summary
- Add Options module with Retail settings panel, slash command handling, and weight reset support
- Wire slash command to Options module and include new file in TOC
- Document settings in health status and advance plan to DetailsBridge work

## Testing
- `luac -p Smartbot/Options.lua Smartbot/Core.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bbc365cc0c8328ba5dd5674e5375a4