### PR TITLE
Fix addon init order and migrate options to Settings API

### DIFF
--- a/Smartbot/Core.lua
+++ b/Smartbot/Core.lua
@@ -3,17 +3,14 @@ _G.Smartbot = Smartbot
 
 Smartbot.SCHEMA_VERSION = 1
 
-local API = Smartbot.API
-local CreateFrame = API:Resolve('CreateFrame') or CreateFrame
-local InCombatLockdown = API:Resolve('InCombatLockdown') or InCombatLockdown
-local UnitAffectingCombat = API:Resolve('UnitAffectingCombat') or UnitAffectingCombat
-local EquipItemByName = API:Resolve('EquipItemByName') or EquipItemByName
-local C_Timer_After = API:Resolve('C_Timer.After') or (C_Timer and C_Timer.After)
+local CreateFrame = CreateFrame
+local InCombatLockdown = InCombatLockdown
+local UnitAffectingCombat = UnitAffectingCombat
+local EquipItemByName = EquipItemByName
+local C_Timer_After = C_Timer and C_Timer.After
 
 local eventFrame = CreateFrame("Frame")
 local equipQueue = {}
-
-Smartbot.db = SmartbotDB or {}
 local defaults = {
     version = Smartbot.SCHEMA_VERSION,
     profile = {
@@ -83,6 +80,9 @@ local function onAddonLoaded(name)
         migrate(Smartbot.db, prev)
     end
     copyDefaults(Smartbot.db, defaults)
+    if Smartbot.Options and Smartbot.Options.Build then
+        Smartbot.Options.Build()
+    end
 end
 
 local function onPlayerLogin()

--- a/Smartbot/HEALTHCHECK.lua
+++ b/Smartbot/HEALTHCHECK.lua
@@ -68,10 +68,16 @@ function Health:CheckAPIIntegrity()
                     if type(fn) == 'function' then
                         local i = 1
                         while true do
-                            local up, _ = debug.getupvalue(fn, i)
+                            local up, val = debug.getupvalue(fn, i)
                             if not up then break end
                             if up == 'GetItemStats' then
                                 error('Forbidden upvalue GetItemStats in '..name..'.'..fname)
+                            end
+                            if up == 'API' and val == nil then
+                                error('Nil API upvalue in '..name..'.'..fname)
+                            end
+                            if up == 'InterfaceOptions_AddCategory' or up == 'InterfaceOptionsFrame_OpenToCategory' then
+                                error('Forbidden upvalue '..up..' in '..name..'.'..fname)
                             end
                             i = i + 1
                         end

--- a/Smartbot/ItemScore.lua
+++ b/Smartbot/ItemScore.lua
@@ -3,12 +3,15 @@ Smartbot.ItemScore = Smartbot.ItemScore or {}
 local ItemScore = Smartbot.ItemScore
 
 local API = Smartbot.API
-local API_GetItemStats = Smartbot.API.GetItemStatsSafe
 local GetItemInfoInstant = API:Resolve('GetItemInfoInstant') or (C_Item and C_Item.GetItemInfoInstant)
 local UnitClass = API:Resolve('UnitClass') or UnitClass
 local GetSpecialization = API:Resolve('GetSpecialization') or GetSpecialization
 
 local ClassSpecRules = Smartbot.ClassSpecRules or {}
+
+local function GetStats(link)
+    return Smartbot.API.GetItemStatsSafe(link)
+end
 
 -- Weapon and armor type mappings derived from ZygorGuidesViewer/Code-Retail/Item-DataTables.lua (MIT License)
 local weaponTypeMap = {
@@ -65,7 +68,7 @@ function ItemScore:GetScore(itemLink)
         end
         return 0
     end
-    local stats = API_GetItemStats(itemLink) or {}
+    local stats = GetStats(itemLink) or {}
     local class, spec = getPlayerSpec()
     local weights = (Smartbot.db.weights[class] and Smartbot.db.weights[class][spec]) or {}
     local score = 0

--- a/Smartbot/Model.lua
+++ b/Smartbot/Model.lua
@@ -7,7 +7,6 @@ local CreateFrame = API:Resolve('CreateFrame') or CreateFrame
 local UnitClass = API:Resolve('UnitClass') or UnitClass
 local GetSpecialization = API:Resolve('GetSpecialization') or GetSpecialization
 local GetInventoryItemLink = API:Resolve('GetInventoryItemLink') or GetInventoryItemLink
-local API_GetItemStats = Smartbot.API.GetItemStatsSafe
 local GetTime = API:Resolve('GetTime') or GetTime
 
 local DetailsBridge = Smartbot.DetailsBridge
@@ -21,12 +20,16 @@ local function currentKey()
     return class, spec
 end
 
+local function GetStats(link)
+    return Smartbot.API.GetItemStatsSafe(link)
+end
+
 local function collectFeatures()
     local stats = {}
     for slot = 1, 17 do
         local link = GetInventoryItemLink('player', slot)
         if link then
-            local istats = API_GetItemStats(link)
+            local istats = GetStats(link)
             if istats then
                 for stat, val in pairs(istats) do
                     stats[stat] = (stats[stat] or 0) + val

--- a/Smartbot/Options.lua
+++ b/Smartbot/Options.lua
@@ -2,15 +2,12 @@ local addonName, Smartbot = ...
 Smartbot.Options = Smartbot.Options or {}
 local Options = Smartbot.Options
 
-local API = Smartbot.API
-local CreateFrame = API:Resolve('CreateFrame') or CreateFrame
-local InterfaceOptions_AddCategory = API:Resolve('InterfaceOptions_AddCategory')
-local InterfaceOptionsFrame_OpenToCategory = API:Resolve('InterfaceOptionsFrame_OpenToCategory')
-local Settings_RegisterCanvasLayoutCategory = API:Resolve('Settings.RegisterCanvasLayoutCategory')
-local Settings_RegisterAddOnCategory = API:Resolve('Settings.RegisterAddOnCategory')
-local Settings_OpenToCategory = API:Resolve('Settings.OpenToCategory')
-local UnitClass = API:Resolve('UnitClass') or UnitClass
-local GetSpecialization = API:Resolve('GetSpecialization') or GetSpecialization
+local CreateFrame = CreateFrame
+local Settings_RegisterCanvasLayoutCategory = Settings and Settings.RegisterCanvasLayoutCategory
+local Settings_RegisterAddOnCategory = Settings and Settings.RegisterAddOnCategory
+local Settings_OpenToCategory = Settings and Settings.OpenToCategory
+local UnitClass = UnitClass
+local GetSpecialization = GetSpecialization
 
 local panel
 
@@ -53,8 +50,10 @@ function Options:Build()
         category.ID = addonName
         Settings_RegisterAddOnCategory(category)
         panel.categoryID = category.ID
-    elseif InterfaceOptions_AddCategory then
-        InterfaceOptions_AddCategory(panel)
+    else
+        if Smartbot.Logger then
+            Smartbot.Logger:Log('WARN', 'Settings API unavailable')
+        end
     end
 
     local title = panel:CreateFontString(nil, 'ARTWORK', 'GameFontNormalLarge')
@@ -117,8 +116,6 @@ function Options:Open()
     Options:Build()
     if Settings_OpenToCategory and panel.categoryID then
         Settings_OpenToCategory(panel.categoryID)
-    elseif InterfaceOptionsFrame_OpenToCategory then
-        InterfaceOptionsFrame_OpenToCategory(panel)
     end
 end
 
@@ -146,10 +143,4 @@ function Options:HandleSlash(msg)
     end
     return false
 end
-
-local initFrame = CreateFrame('Frame')
-initFrame:RegisterEvent('PLAYER_LOGIN')
-initFrame:SetScript('OnEvent', function()
-    Options:Build()
-end)
 


### PR DESCRIPTION
## Summary
- initialize saved variables and build options after `ADDON_LOADED`
- provide guarded item stat API and adapt all modules to use it
- migrate configuration UI to Retail Settings API and add health checks

## Testing
- `luac -p Core.lua API.lua ItemScore.lua Model.lua Options.lua HEALTHCHECK.lua` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bc018cff988328bfcaaf899897adba