### PR TITLE
refactor: avoid cached api globals

### DIFF
--- a/Smartbot/Core.lua
+++ b/Smartbot/Core.lua
@@ -3,12 +3,7 @@ _G.Smartbot = Smartbot
 
 Smartbot.SCHEMA_VERSION = 1
 
-local CreateFrame = CreateFrame
-local UnitAffectingCombat = UnitAffectingCombat
-local EquipItemByName = EquipItemByName
-local C_Timer_After = C_Timer and C_Timer.After
-
-local eventFrame = CreateFrame("Frame")
+local eventFrame = _G.CreateFrame("Frame")
 local equipQueue = {}
 local defaults = {
     version = Smartbot.SCHEMA_VERSION,
@@ -41,7 +36,9 @@ local function migrate(db, old)
 end
 
 local function processQueue()
-    if not (Smartbot.API and Smartbot.API.IsOutOfCombat and Smartbot.API.IsOutOfCombat()) or UnitAffectingCombat("player") then return end
+    if not (Smartbot.API and Smartbot.API.IsOutOfCombat and Smartbot.API.IsOutOfCombat()) or _G.UnitAffectingCombat("player") then
+        return
+    end
     if #equipQueue == 0 then return end
     local entry = table.remove(equipQueue, 1)
     if entry then
@@ -50,7 +47,7 @@ local function processQueue()
             if Smartbot.Equip and Smartbot.Equip.Validate and not Smartbot.Equip:Validate(item, slot) then
                 -- skip invalid or outdated entry
             else
-                local ok, err = pcall(EquipItemByName, item, slot)
+                local ok, err = pcall(_G.EquipItemByName, item, slot)
                 if not ok and Smartbot.Logger then
                     Smartbot.Logger:Log("WARN", "Equip failed", item, err)
                 end
@@ -58,7 +55,10 @@ local function processQueue()
         end
     end
     if #equipQueue > 0 then
-        C_Timer_After(0.5, processQueue)
+        local after = _G.C_Timer and _G.C_Timer.After
+        if after then
+            after(0.5, processQueue)
+        end
     end
 end
 
@@ -101,3 +101,5 @@ end)
 eventFrame:RegisterEvent("ADDON_LOADED")
 eventFrame:RegisterEvent("PLAYER_LOGIN")
 eventFrame:RegisterEvent("PLAYER_REGEN_ENABLED")
+
+return Smartbot

--- a/Smartbot/HEALTHCHECK.lua
+++ b/Smartbot/HEALTHCHECK.lua
@@ -1,12 +1,5 @@
 local addonName, Smartbot = ...
 Smartbot.HealthCheck = Smartbot.HealthCheck or {}
-local Health = Smartbot.HealthCheck
-
-local CreateFrame = CreateFrame
-local GetBuildInfo = GetBuildInfo
-local InCombatLockdown = InCombatLockdown
-local UnitAffectingCombat = UnitAffectingCombat
-local hooksecurefunc = hooksecurefunc
 
 Smartbot.interface = Smartbot.interface or 110200
 
@@ -18,7 +11,7 @@ local requiredAPIs = {
     'UnitAffectingCombat',
 }
 
-function Health:CheckAPIs()
+function Smartbot.HealthCheck:CheckAPIs()
     for _, sym in ipairs(requiredAPIs) do
         local obj = _G[sym]
         if not obj and Smartbot.Logger then
@@ -27,8 +20,8 @@ function Health:CheckAPIs()
     end
 end
 
-function Health:CheckInterface()
-    local build = select(4, GetBuildInfo())
+function Smartbot.HealthCheck:CheckInterface()
+    local build = select(4, _G.GetBuildInfo())
     local game = tonumber(build, 10) or 0
     if Smartbot.interface and game ~= Smartbot.interface then
         if Smartbot.Logger then
@@ -37,21 +30,21 @@ function Health:CheckInterface()
     end
 end
 
-function Health:CheckLoadOrder()
+function Smartbot.HealthCheck:CheckLoadOrder()
     if not Smartbot.db and Smartbot.Logger then
         Smartbot.Logger:Log('ERROR', 'Core not loaded before health check')
     end
 end
 
-function Health:CheckDBVersion()
+function Smartbot.HealthCheck:CheckDBVersion()
     if Smartbot.db and Smartbot.SCHEMA_VERSION and Smartbot.db.version ~= Smartbot.SCHEMA_VERSION then
         if Smartbot.Logger then
-            Smartbot.Logger:Log('ERROR', 'DB schema mismatch', Smartbot.db.version or "nil", Smartbot.SCHEMA_VERSION)
+            Smartbot.Logger:Log('ERROR', 'DB schema mismatch', Smartbot.db.version or 'nil', Smartbot.SCHEMA_VERSION)
         end
     end
 end
 
-function Health:CheckAdapter()
+function Smartbot.HealthCheck:CheckAdapter()
     assert(type(Smartbot.API) == 'table' and type(Smartbot.API.GetItemStatsSafe) == 'function', 'Missing Smartbot.API.GetItemStatsSafe')
     if debug and debug.getupvalue then
         for name, mod in pairs(Smartbot) do
@@ -78,15 +71,15 @@ function Health:CheckAdapter()
     end
 end
 
-function Health:CheckOptions()
-    if not (Settings and Settings.GetCategory and Smartbot.Options and Smartbot.Options.categoryID) then
+function Smartbot.HealthCheck:CheckOptions()
+    if not (_G.Settings and _G.Settings.GetCategory and Smartbot.Options and Smartbot.Options.categoryID) then
         if Smartbot.Logger then
             Smartbot.Logger:Log('WARN', 'Options not registered with Settings')
         end
     end
 end
 
-function Health:Verify()
+function Smartbot.HealthCheck:Verify()
     self:CheckLoadOrder()
     self:CheckAPIs()
     self:CheckInterface()
@@ -95,9 +88,9 @@ function Health:Verify()
     self:CheckOptions()
 end
 
-if hooksecurefunc then
-    hooksecurefunc('EquipItemByName', function()
-        if InCombatLockdown() or UnitAffectingCombat('player') then
+if _G.hooksecurefunc then
+    _G.hooksecurefunc('EquipItemByName', function()
+        if _G.InCombatLockdown() or _G.UnitAffectingCombat('player') then
             if Smartbot.Logger then
                 Smartbot.Logger:Log('ERROR', 'Equip attempted in combat')
             end
@@ -105,12 +98,12 @@ if hooksecurefunc then
     end)
 end
 
-local frame = CreateFrame('Frame')
+local frame = _G.CreateFrame('Frame')
 frame:RegisterEvent('ADDON_LOADED')
 frame:SetScript('OnEvent', function(_, _, name)
     if name == addonName then
-        Health:Verify()
+        Smartbot.HealthCheck:Verify()
     end
 end)
 
-return Health
+return Smartbot.HealthCheck

--- a/Smartbot/Logger.lua
+++ b/Smartbot/Logger.lua
@@ -1,21 +1,25 @@
 local addonName, Smartbot = ...
 Smartbot.Logger = Smartbot.Logger or {}
-local Logger = Smartbot.Logger
 
-local MAX_LOGS = 100
 local buffer = {}
+local MAX_LOGS = 100
 
-function Logger:Log(level, ...)
+function Smartbot.Logger:Log(level, ...)
     local msg = table.concat({...}, " ")
     if #buffer >= MAX_LOGS then
         table.remove(buffer, 1)
     end
-    table.insert(buffer, {time = GetTime(), level = level, msg = msg})
+    table.insert(buffer, {time = _G.GetTime(), level = level, msg = msg})
     if Smartbot.db and Smartbot.db.profile and Smartbot.db.profile.verbosity > 0 then
-        DEFAULT_CHAT_FRAME:AddMessage("|cff33ff99Smartbot|r " .. msg)
+        local frame = _G.DEFAULT_CHAT_FRAME
+        if frame and frame.AddMessage then
+            frame:AddMessage("|cff33ff99Smartbot|r " .. msg)
+        end
     end
 end
 
-function Logger:Get()
+function Smartbot.Logger:Get()
     return buffer
 end
+
+return Smartbot.Logger

--- a/Smartbot/Options.lua
+++ b/Smartbot/Options.lua
@@ -1,20 +1,12 @@
 local addonName, Smartbot = ...
 Smartbot.Options = Smartbot.Options or {}
-local Options = Smartbot.Options
-
-local CreateFrame = CreateFrame
-local Settings_RegisterCanvasLayoutCategory = Settings and Settings.RegisterCanvasLayoutCategory
-local Settings_RegisterAddOnCategory = Settings and Settings.RegisterAddOnCategory
-local Settings_OpenToCategory = Settings and Settings.OpenToCategory
-local UnitClass = UnitClass
-local GetSpecialization = GetSpecialization
 
 local panel
 
 local function getCurrentWeights()
-    local class = select(2, UnitClass('player'))
-    local spec = GetSpecialization() or 0
-    return (Smartbot.db and Smartbot.db.weights and Smartbot.db.weights[class] and Smartbot.db.weights[class][spec]) or {}
+    local class = select(2, _G.UnitClass('player'))
+    local spec = _G.GetSpecialization() or 0
+    return Smartbot.db and Smartbot.db.weights and Smartbot.db.weights[class] and Smartbot.db.weights[class][spec] or {}
 end
 
 local function updateWeightText()
@@ -27,7 +19,7 @@ local function updateWeightText()
     panel.weightText:SetText(#parts > 0 and table.concat(parts, ', ') or 'No weights yet')
 end
 
-function Options:ResetWeights()
+function Smartbot.Options:ResetWeights()
     if Smartbot.db then
         Smartbot.db.weights = {}
         Smartbot.db.modelMeta = {}
@@ -35,21 +27,21 @@ function Options:ResetWeights()
         if Smartbot.Logger then
             Smartbot.Logger:Log('INFO', 'Weights reset')
         else
-            print('Smartbot: weights reset')
+            _G.print('Smartbot: weights reset')
         end
     end
 end
 
-function Options:Build()
+function Smartbot.Options.Build()
     if not Smartbot.db then return end
     if panel then return panel end
-    panel = CreateFrame('Frame')
+    panel = _G.CreateFrame('Frame')
 
-    if Settings_RegisterCanvasLayoutCategory and Settings_RegisterAddOnCategory then
-        local category = Settings_RegisterCanvasLayoutCategory(panel, 'Smartbot')
-        Settings_RegisterAddOnCategory(category)
+    if _G.Settings and _G.Settings.RegisterCanvasLayoutCategory and _G.Settings.RegisterAddOnCategory then
+        local category = _G.Settings.RegisterCanvasLayoutCategory(panel, 'Smartbot')
+        _G.Settings.RegisterAddOnCategory(category)
         panel.categoryID = category.ID
-        Options.categoryID = category.ID
+        Smartbot.Options.categoryID = category.ID
     else
         if Smartbot.Logger then
             Smartbot.Logger:Log('WARN', 'Settings API unavailable')
@@ -60,7 +52,7 @@ function Options:Build()
     title:SetPoint('TOPLEFT', 16, -16)
     title:SetText('Smartbot')
 
-    local auto = CreateFrame('CheckButton', nil, panel, 'InterfaceOptionsCheckButtonTemplate')
+    local auto = _G.CreateFrame('CheckButton', nil, panel, 'InterfaceOptionsCheckButtonTemplate')
     auto:SetPoint('TOPLEFT', title, 'BOTTOMLEFT', 0, -8)
     auto.Text:SetText('Enable Auto Equip')
     auto:SetChecked(Smartbot.db.profile.autoEquip)
@@ -68,7 +60,7 @@ function Options:Build()
         Smartbot.db.profile.autoEquip = self:GetChecked()
     end)
 
-    local minDelta = CreateFrame('Slider', addonName..'MinDelta', panel, 'OptionsSliderTemplate')
+    local minDelta = _G.CreateFrame('Slider', addonName..'MinDelta', panel, 'OptionsSliderTemplate')
     minDelta:SetPoint('TOPLEFT', auto, 'BOTTOMLEFT', 0, -24)
     minDelta:SetMinMaxValues(0, 100)
     minDelta:SetValueStep(1)
@@ -81,7 +73,7 @@ function Options:Build()
         Smartbot.db.profile.minDelta = math.floor(value + 0.5)
     end)
 
-    local verb = CreateFrame('Slider', addonName..'Verbosity', panel, 'OptionsSliderTemplate')
+    local verb = _G.CreateFrame('Slider', addonName..'Verbosity', panel, 'OptionsSliderTemplate')
     verb:SetPoint('TOPLEFT', minDelta, 'BOTTOMLEFT', 0, -24)
     verb:SetMinMaxValues(0, 3)
     verb:SetValueStep(1)
@@ -102,22 +94,22 @@ function Options:Build()
     panel.weightText = wt
     updateWeightText()
 
-    local reset = CreateFrame('Button', nil, panel, 'UIPanelButtonTemplate')
+    local reset = _G.CreateFrame('Button', nil, panel, 'UIPanelButtonTemplate')
     reset:SetText('Reset Weights')
     reset:SetWidth(120)
     reset:SetHeight(22)
     reset:SetPoint('TOPLEFT', wt, 'BOTTOMLEFT', 0, -24)
-    reset:SetScript('OnClick', function() Options:ResetWeights() end)
+    reset:SetScript('OnClick', function() Smartbot.Options:ResetWeights() end)
 
     return panel
 end
 
-function Options:Open()
-    Options:Build()
-    if Settings_OpenToCategory and Options.categoryID then
-        Settings_OpenToCategory(Options.categoryID)
-    elseif Settings and SettingsPanel then
-        SettingsPanel:Show()
+function Smartbot.Options.Open()
+    Smartbot.Options.Build()
+    if _G.Settings and _G.Settings.OpenToCategory and Smartbot.Options.categoryID then
+        _G.Settings.OpenToCategory(Smartbot.Options.categoryID)
+    elseif _G.SettingsPanel then
+        _G.SettingsPanel:Show()
     end
 end
 
@@ -125,10 +117,10 @@ local function trim(s)
     return s:match('^%s*(.-)%s*$')
 end
 
-function Options:HandleSlash(msg)
+function Smartbot.Options.HandleSlash(msg)
     msg = trim(msg or ''):lower()
     if msg == '' or msg == 'options' then
-        Options:Open()
+        Smartbot.Options.Open()
         return true
     elseif msg == 'auto' then
         if Smartbot.db and Smartbot.db.profile then
@@ -137,22 +129,23 @@ function Options:HandleSlash(msg)
             if Smartbot.Logger then
                 Smartbot.Logger:Log('INFO', 'AutoEquip', state)
             else
-                print('Smartbot auto-equip', state)
+                _G.print('Smartbot auto-equip', state)
             end
         end
         return true
     elseif msg == 'reset' then
-        Options:ResetWeights()
+        Smartbot.Options:ResetWeights()
         return true
     end
-    Options:Open()
+    Smartbot.Options.Open()
     return true
 end
 
 SLASH_SMARTBOT1 = '/smartbot'
 SlashCmdList.SMARTBOT = function(msg)
-    if not Options:HandleSlash(msg) then
-        Options:Open()
+    if not Smartbot.Options.HandleSlash(msg) then
+        Smartbot.Options.Open()
     end
 end
 
+return Smartbot.Options

--- a/smartbot.plan.json
+++ b/smartbot.plan.json
@@ -1,36 +1,76 @@
 {
   "interface": 110200,
   "tasks": [
-    {"id": 1, "name": "Bootstrap project (toc, Core, Logger, README, LICENSE, THIRD_PARTY_NOTICES)", "status": "complete"},
-    {"id": 2, "name": "Create API.lua, remove any APIMap.lua, update references", "status": "complete"},
-    {"id": 3, "name": "ClassSpecRules + ItemScore scaffolding (from Zygor Retail → normalized)", "status": "complete"},
-    {"id": 4, "name": "Equip pipeline with OOC queue, min-delta, slot coupling", "status": "complete"},
-    {"id": 5, "name": "Tooltip integration (Retail-safe guarded pattern)", "status": "complete"},
-    {"id": 6, "name": "Settings UI and `/smartbot`", "status": "complete"},
-    {"id": 7, "name": "DetailsBridge + internal meter fallback", "status": "complete"},
-    {"id": 8, "name": "Online learner + persistence + quality gates", "status": "complete"},
-    {"id": 9, "name": "Health checks + HEALTH.md; auto-fix obvious issues", "status": "complete"},
-    {"id": 10, "name": "Polish: docs, schema migrator, logging, final cleanup", "status": "complete"}
+    {
+      "id": 1,
+      "name": "Bootstrap project (toc, Core, Logger, README, LICENSE, THIRD_PARTY_NOTICES)",
+      "status": "complete"
+    },
+    {
+      "id": 2,
+      "name": "Create API.lua, remove any APIMap.lua, update references",
+      "status": "complete"
+    },
+    {
+      "id": 3,
+      "name": "ClassSpecRules + ItemScore scaffolding (from Zygor Retail \u2192 normalized)",
+      "status": "complete"
+    },
+    {
+      "id": 4,
+      "name": "Equip pipeline with OOC queue, min-delta, slot coupling",
+      "status": "complete"
+    },
+    {
+      "id": 5,
+      "name": "Tooltip integration (Retail-safe guarded pattern)",
+      "status": "complete"
+    },
+    {
+      "id": 6,
+      "name": "Settings UI and `/smartbot`",
+      "status": "complete"
+    },
+    {
+      "id": 7,
+      "name": "DetailsBridge + internal meter fallback",
+      "status": "complete"
+    },
+    {
+      "id": 8,
+      "name": "Online learner + persistence + quality gates",
+      "status": "complete"
+    },
+    {
+      "id": 9,
+      "name": "Health checks + HEALTH.md; auto-fix obvious issues",
+      "status": "complete"
+    },
+    {
+      "id": 10,
+      "name": "Polish: docs, schema migrator, logging, final cleanup",
+      "status": "complete"
+    }
   ],
   "file_checksums": {
     "Smartbot/Smartbot.toc": "2a4b276439efe9b730b114c022cdba9d8c53d6d43cac968dceaf9f3789f4b7cd",
-    "Smartbot/Core.lua": "29c1ef94aba70dfb0733d5a789969e0529595d720a2b51774b31982fc9fcd653",
-    "Smartbot/Logger.lua": "fab85d15b7129059aeaf30a0017ef636ebe814016c9587f61564f5d24ed74c14",
+    "Smartbot/Core.lua": "b21514c6616bad0e2674d857fcc6564c8d9ec2022cfa90fe3a0202ee3fe82ac9",
+    "Smartbot/Logger.lua": "6a3df7fa8c50c0f71c1b654555d6ebf5d158039a886a681a24374028ff646a84",
     "README.md": "ba5602551e24079bce46dfa305c2aac9c6ec0efd76762b8674e62f9bf3b221b8",
     "LICENSE": "731683113662b881f8b6ad6fa743c5d8bd9eb488ec2011104e384665cd1d6443",
     "THIRD_PARTY_NOTICES.md": "cab8b2aa1202c7604dcea720b3fabf10c8356d57c0c694ade8675302c5d7235d",
     "Smartbot/API.lua": "904850de59a51977b84f0d0c9dfd582b223a4b53f2b110cbda914a16b431a21e",
     "Smartbot/HEALTH.md": "1225771c2135e7d2d1d3d6d9a606ec2f35f8f9a397360c774ef34d3a40a60718",
     "Smartbot/ClassSpecRules.lua": "4e0f7a81b8169776d3111f151fee3568c5bba7eb7d49c43faa896fd6ec8974aa",
-    "Smartbot/ItemScore.lua": "8af0086ac8c475617c4a571a6a8373d6b6d2aee39b12b9b5253216982ac2a205",
+    "Smartbot/ItemScore.lua": "56bc44e4525aca76dae5fb8eb45ca8a67bad0c38ddb7b734fe4aa49adc405e25",
     "Smartbot/tools/extract_rules.py": "04dea0aee02c0958ce9489d0c2aab3ad1f9e694d0cadee8f08e24e550e485776",
-    "Smartbot/Equip.lua": "ac851daf642e74b51e9f45799bfde60bb46dd549d66b911979beca51ead907ec",
-    "Smartbot/Tooltip.lua": "33b896ed1b87aa401e15021ac25fab57e9e0e4e09649b8dbc7f02fa6189f6c81",
-    "Smartbot/Options.lua": "beeb771db650c5cdd361d69a98f948561dc37358807368a56d2ddbd4a55dcf9a",
+    "Smartbot/Equip.lua": "6f61955a27ed9c2f7240f9e4616dc5dfe043968b9dc643751a473edd9c986865",
+    "Smartbot/Tooltip.lua": "be76b67642146bfcfa2f026b3f861617769cc0f146fe1e931bbfeb21df20ec03",
+    "Smartbot/Options.lua": "1dd1cd388097154271c573b2b6fbb8383314168bbf6fd9ddccab21941ac69f07",
     "Smartbot/DetailsBridge.lua": "37353534b64e47dea20711277325e68bfa47256afb6a5bb5cfa2ceaae3459be9",
     "Smartbot/Meter.lua": "921606e73b867d8a4212e6c62816bd20652b50638fdffd1c2967e0282554c171",
     "Smartbot/Model.lua": "c65c4bc43a27689287cc5246ba4de57faf2999ac5f1db7a58677f3aa54242c58",
-    "Smartbot/HEALTHCHECK.lua": "97fd4fd1e63b58c5f68d7c2b199a7940e73da76766918a970492eb4ee74203d6"
+    "Smartbot/HEALTHCHECK.lua": "7b316e32cca839b3c45aa96468f144c74671d36761fe60a6092cb15be54ec867"
   },
   "next_run_focus": "All tasks complete"
 }


### PR DESCRIPTION
## Summary
- reference Blizzard APIs via `_G` at call sites instead of file-scope locals
- refactor logger, core queue, equipment scanner, options UI, tooltip and health check modules
- keep plan metadata updated

## Testing
- `rg "InterfaceOptions" -n Smartbot || true`
- `apt-get update >/tmp/apt.log && tail -n 20 /tmp/apt.log` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bd49db76a083288dfe91d78122cf68