### PR TITLE
Fix tooltip and equip handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Smartbot is a World of Warcraft Retail addon that learns per-spec stat weights from play and can automatically equip upgrades out of combat. It integrates with Details! Damage Meter when available, falling back to a lightweight internal meter otherwise.
 
+- Tooltip resolver uses TooltipDataProcessor item data (guid/hyperlink/id) rather than per-tooltip methods.
+- Equips prefer automatic slot resolution; explicit slots are only used for ambiguous locations like rings, trinkets and generic weapons.
+
 ## Usage
 1. Install Smartbot in `Interface/AddOns`.
 2. In game, type `/smartbot` to open the settings panel.
@@ -13,3 +16,4 @@ This repository also contains reference addons used for API discovery. Smartbot 
 
 ## License
 Smartbot is released under the MIT License. See `LICENSE` for details.
+

--- a/Smartbot/API.lua
+++ b/Smartbot/API.lua
@@ -16,6 +16,13 @@ function Smartbot.API.Resolve(_, symbol)
     return resolvePath(symbol)
 end
 
+function Smartbot.API.IsValidItemLink(link)
+    if type(link) ~= "string" then return false end
+    if string.find(link, "|Hitem:") then return true end
+    if string.match(link, "^item:%d+") then return true end
+    return false
+end
+
 function Smartbot.API.GetItemStatsSafe(itemLink)
     if type(itemLink) ~= "string" then return {} end
     local API_GetItemStats = _G and _G.GetItemStats

--- a/Smartbot/Core.lua
+++ b/Smartbot/Core.lua
@@ -47,7 +47,7 @@ local function processQueue()
             if Smartbot.Equip and Smartbot.Equip.Validate and not Smartbot.Equip:Validate(item, slot) then
                 -- skip invalid or outdated entry
             else
-                local ok, err = pcall(_G.EquipItemByName, item, slot)
+                local ok, err = Smartbot.Equip and Smartbot.Equip.SafeEquipLink and Smartbot.Equip.SafeEquipLink(item, nil, nil, slot)
                 if not ok and Smartbot.Logger then
                     Smartbot.Logger:Log("WARN", "Equip failed", item, err)
                 end
@@ -103,3 +103,4 @@ eventFrame:RegisterEvent("PLAYER_LOGIN")
 eventFrame:RegisterEvent("PLAYER_REGEN_ENABLED")
 
 return Smartbot
+

--- a/Smartbot/HEALTH.md
+++ b/Smartbot/HEALTH.md
@@ -3,11 +3,12 @@
 ## Status
 - Core, logger, runtime API adapter, class/spec rules and item scoring ready
 - Equip pipeline with OOC queue, min-delta damping, and slot coupling active
-- Tooltip score deltas integrated via guarded Retail hook
+- Tooltip score deltas integrated via TooltipDataProcessor item data
 - Settings UI registered through Retail Settings API and /smartbot opens it
 - DetailsBridge with fallback internal meter operational
 - Online learner with per-spec weights and persistence active
-- Health checks validate API availability, interface version, load order, combat safety, DB schema version, adapter usage and Settings registration; warns on stray GetItemStats locals
+- Health checks validate API availability, interface version, load order, combat safety, DB schema version, adapter usage and Settings registration; warn on stray GetItemStats locals, tooltip:GetItem and improper equip slots
 
 ## Next Steps
 - None
+

--- a/smartbot.plan.json
+++ b/smartbot.plan.json
@@ -50,27 +50,32 @@
       "id": 10,
       "name": "Polish: docs, schema migrator, logging, final cleanup",
       "status": "complete"
+    },
+    {
+      "id": 11,
+      "name": "Repair tooltip crash and equip slot taint; add link validation and docs",
+      "status": "complete"
     }
   ],
   "file_checksums": {
     "Smartbot/Smartbot.toc": "2a4b276439efe9b730b114c022cdba9d8c53d6d43cac968dceaf9f3789f4b7cd",
-    "Smartbot/Core.lua": "b21514c6616bad0e2674d857fcc6564c8d9ec2022cfa90fe3a0202ee3fe82ac9",
+    "Smartbot/Core.lua": "8a216dc92ea7afaf19bdd917b43f7a87e90b650c80223e48b749ca06d0e11b30",
     "Smartbot/Logger.lua": "6a3df7fa8c50c0f71c1b654555d6ebf5d158039a886a681a24374028ff646a84",
-    "README.md": "ba5602551e24079bce46dfa305c2aac9c6ec0efd76762b8674e62f9bf3b221b8",
+    "README.md": "7c2983737817851f2cbe760efbc8fac2437bf175c160d8512365914a3a73ab1e",
     "LICENSE": "731683113662b881f8b6ad6fa743c5d8bd9eb488ec2011104e384665cd1d6443",
     "THIRD_PARTY_NOTICES.md": "cab8b2aa1202c7604dcea720b3fabf10c8356d57c0c694ade8675302c5d7235d",
-    "Smartbot/API.lua": "904850de59a51977b84f0d0c9dfd582b223a4b53f2b110cbda914a16b431a21e",
-    "Smartbot/HEALTH.md": "1225771c2135e7d2d1d3d6d9a606ec2f35f8f9a397360c774ef34d3a40a60718",
+    "Smartbot/API.lua": "a46e3629a7d505d19f9a68429d14d057ab0b201035854ce9a7fc36819d50d0a2",
+    "Smartbot/HEALTH.md": "668b76a227e5eab9002589c41ac696ee901992de5dfd9cddac28ebdc5faab0e1",
     "Smartbot/ClassSpecRules.lua": "4e0f7a81b8169776d3111f151fee3568c5bba7eb7d49c43faa896fd6ec8974aa",
-    "Smartbot/ItemScore.lua": "56bc44e4525aca76dae5fb8eb45ca8a67bad0c38ddb7b734fe4aa49adc405e25",
+    "Smartbot/ItemScore.lua": "9242ea771b20f6679e1929a36659262fd7c7664f459a28562b6a432553623ed0",
     "Smartbot/tools/extract_rules.py": "04dea0aee02c0958ce9489d0c2aab3ad1f9e694d0cadee8f08e24e550e485776",
-    "Smartbot/Equip.lua": "6f61955a27ed9c2f7240f9e4616dc5dfe043968b9dc643751a473edd9c986865",
-    "Smartbot/Tooltip.lua": "be76b67642146bfcfa2f026b3f861617769cc0f146fe1e931bbfeb21df20ec03",
+    "Smartbot/Equip.lua": "07a69356c1cfbdcada433dbb96c9b19cf865e8968497893914c1e7fc71b8dcb7",
+    "Smartbot/Tooltip.lua": "048ce4f8384ca83044e5295db100378926f9e979ec53b8eccf1e203736577e9b",
     "Smartbot/Options.lua": "1dd1cd388097154271c573b2b6fbb8383314168bbf6fd9ddccab21941ac69f07",
     "Smartbot/DetailsBridge.lua": "37353534b64e47dea20711277325e68bfa47256afb6a5bb5cfa2ceaae3459be9",
     "Smartbot/Meter.lua": "921606e73b867d8a4212e6c62816bd20652b50638fdffd1c2967e0282554c171",
     "Smartbot/Model.lua": "c65c4bc43a27689287cc5246ba4de57faf2999ac5f1db7a58677f3aa54242c58",
-    "Smartbot/HEALTHCHECK.lua": "7b316e32cca839b3c45aa96468f144c74671d36761fe60a6092cb15be54ec867"
+    "Smartbot/HEALTHCHECK.lua": "6dbadc29104f28ce2fa93c7051ea63bec3a24c9385ca61dbb6dc02590c0ae93d"
   },
-  "next_run_focus": "All tasks complete"
+  "next_run_focus": "None"
 }


### PR DESCRIPTION
## Summary
- Resolve tooltip item link via TooltipDataProcessor data and guard invalid links
- Add SafeEquipLink to auto-slot or choose weaker slot for ambiguous items
- Validate item links across API/ItemScore and extend health checks and docs

## Testing
- `luac -p Smartbot/API.lua Smartbot/Core.lua Smartbot/Equip.lua Smartbot/HEALTHCHECK.lua Smartbot/ItemScore.lua Smartbot/Tooltip.lua` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bd56a91f1c83288920eb0909d375af